### PR TITLE
feat: Add core Laravel service config overrides

### DIFF
--- a/src/Exceptions/BudException.php
+++ b/src/Exceptions/BudException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Exceptions;
+
+use Exception;
+
+abstract class BudException extends Exception
+{
+
+}

--- a/src/Exceptions/CyclicOverrideException.php
+++ b/src/Exceptions/CyclicOverrideException.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Sprout\Bud\Exceptions;
 
-final class CyclicOverrideException extends \LogicException
+final class CyclicOverrideException extends BudException
 {
     public static function make(string $term, string $name): self
     {

--- a/src/Exceptions/CyclicOverrideException.php
+++ b/src/Exceptions/CyclicOverrideException.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Exceptions;
+
+final class CyclicOverrideException extends \LogicException
+{
+    public static function make(string $term, string $name): self
+    {
+        return new self(sprintf(
+            'Attempt to create cyclic bud %s [%s] detected',
+            $term,
+            $name
+        ));
+    }
+}

--- a/src/Overrides/Auth/BudAuthManager.php
+++ b/src/Overrides/Auth/BudAuthManager.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides\Auth;
+
+use Illuminate\Auth\AuthManager;
+use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+
+class BudAuthManager extends AuthManager
+{
+    protected bool $syncedFromOriginal = false;
+
+    public function __construct($app, ?AuthManager $original = null)
+    {
+        parent::__construct($app);
+
+        if ($original) {
+            $this->syncOriginal($original);
+        }
+    }
+
+    /**
+     * Check if this manager override was synced from the original
+     *
+     * @return bool
+     */
+    public function wasSyncedFromOriginal(): bool
+    {
+        return $this->syncedFromOriginal;
+    }
+
+    /**
+     * Sync the original manager in case things have been registered
+     *
+     * @param \Illuminate\Auth\AuthManager $original
+     *
+     * @return void
+     */
+    private function syncOriginal(AuthManager $original): void
+    {
+        $this->customCreators         = array_merge($original->customCreators, $this->customCreators);
+        $this->guards                 = array_merge($original->guards, $this->guards);
+        $this->userResolver           = $original->userResolver;
+        $this->customProviderCreators = array_merge($original->customProviderCreators, $this->customProviderCreators);
+        $this->syncedFromOriginal     = true;
+    }
+
+    /**
+     * Create the user provider implementation for the driver.
+     *
+     * @param string|null $provider
+     *
+     * @return \Illuminate\Contracts\Auth\UserProvider|null
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function createUserProvider($provider = null): ?UserProvider
+    {
+        $provider ??= $this->getDefaultUserProvider();
+        $config   = $this->getProviderConfiguration($provider);
+
+        if ($config === null) {
+            return null;
+        }
+
+        $config = Arr::add($config, 'provider', $provider);
+
+        /** @var array<string, mixed>|array{provider:string,driver?:string|null} $config */
+
+        return $this->createUserProviderFromConfig($config);
+    }
+
+    /**
+     * Create the user provider implementation from the given configuration.
+     *
+     * @param array<string, mixed>|array{provider:string,driver?:string|null} $config
+     *
+     * @return \Illuminate\Contracts\Auth\UserProvider|null
+     */
+    public function createUserProviderFromConfig(array $config): ?UserProvider
+    {
+        $driver = $config['driver'] ?? null;
+
+        if ($driver === null) {
+            throw new InvalidArgumentException('Authentication user provider driver must be provided.');
+        }
+
+        /** @var string $driver */
+
+        if (isset($this->customProviderCreators[$driver])) {
+            $creator = $this->customProviderCreators[$driver];
+            /** @var \Closure(\Illuminate\Contracts\Foundation\Application, array<string, mixed>):UserProvider|null $creator */
+
+            /** @phpstan-ignore callable.nonCallable */
+            return $creator($this->app, $config);
+        }
+
+        /** @var \Illuminate\Contracts\Auth\UserProvider|null */
+        return match ($driver) {
+            'database' => $this->createDatabaseProvider($config),
+            'eloquent' => $this->createEloquentProvider($config),
+            default    => throw new InvalidArgumentException(
+                "Authentication user provider [{$driver}] is not defined."
+            ),
+        };
+    }
+}

--- a/src/Overrides/Auth/BudAuthManager.php
+++ b/src/Overrides/Auth/BudAuthManager.php
@@ -93,7 +93,12 @@ class BudAuthManager extends AuthManager
             $creator = $this->customProviderCreators[$driver];
             /** @var \Closure(\Illuminate\Contracts\Foundation\Application, array<string, mixed>):UserProvider|null $creator */
 
-            /** @phpstan-ignore callable.nonCallable */
+            /**
+             * This has to be here because no matter how I provide it, it
+             * misread the type of creator as being nullable, which it is not.
+             *
+             * @phpstan-ignore callable.nonCallable
+             */
             return $creator($this->app, $config);
         }
 

--- a/src/Overrides/Auth/BudAuthProviderCreator.php
+++ b/src/Overrides/Auth/BudAuthProviderCreator.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides\Auth;
+
+use Illuminate\Contracts\Auth\UserProvider;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Overrides\BaseCreator;
+use Sprout\Sprout;
+
+final class BudAuthProviderCreator extends BaseCreator
+{
+    private BudAuthManager $manager;
+
+    private Bud $bud;
+
+    private Sprout $sprout;
+
+    private string $name;
+
+    /**
+     * @var array<string, mixed>&array{budStore?:string|null}
+     */
+    private array $config;
+
+    /**
+     * @param \Sprout\Bud\Overrides\Auth\BudAuthManager         $manager
+     * @param \Sprout\Bud\Bud                                   $bud
+     * @param \Sprout\Sprout                                    $sprout
+     * @param string                                            $name
+     * @param array<string, mixed>&array{budStore?:string|null} $config
+     */
+    public function __construct(
+        BudAuthManager $manager,
+        Bud            $bud,
+        Sprout         $sprout,
+        string         $name,
+        array          $config
+    )
+    {
+        $this->manager = $manager;
+        $this->bud     = $bud;
+        $this->sprout  = $sprout;
+        $this->name    = $name;
+        $this->config  = $config;
+    }
+
+
+    /**
+     * Get the name of the service for the creator.
+     *
+     * @return string
+     */
+    protected function getService(): string
+    {
+        return 'auth';
+    }
+
+    public function __invoke(): ?UserProvider
+    {
+        /** @var array<string, mixed>&array{driver:string|null} $config */
+        $config = $this->getConfig($this->sprout, $this->bud, $this->config, $this->name);
+
+        // We need to make sure that this isn't going to recurse infinitely.
+        $this->checkForCyclicDrivers(
+            $config['driver'] ?? null,
+            'auth provider',
+            $this->name
+        );
+
+        return $this->manager->createUserProviderFromConfig($config);
+    }
+}

--- a/src/Overrides/AuthManagerOverride.php
+++ b/src/Overrides/AuthManagerOverride.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides;
+
+use Illuminate\Contracts\Foundation\Application;
+use Sprout\Bud\Overrides\Auth\BudAuthManager;
+use Sprout\Contracts\BootableServiceOverride;
+use Sprout\Overrides\BaseOverride;
+use Sprout\Sprout;
+
+final class AuthManagerOverride extends BaseOverride implements BootableServiceOverride
+{
+    /**
+     * Boot a service override
+     *
+     * This method should perform any initial steps required for the service
+     * override that take place during the booting of the framework.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param \Sprout\Sprout                               $sprout
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function boot(Application $app, Sprout $sprout): void
+    {
+        $original = null;
+
+        // If the auth manager has already been resolved
+        if ($app->resolved('auth')) {
+            // We'll grab the manager
+            $original = $app->make('auth');
+            // and then tell the container to forget it
+            $app->forgetInstance('auth');
+        }
+
+        // Bind a replacement auth manager to enable Bud features
+        $app->singleton('auth', fn (Application $app) => new BudAuthManager($app, $original));
+    }
+}

--- a/src/Overrides/AuthProviderOverride.php
+++ b/src/Overrides/AuthProviderOverride.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides;
+
+use Closure;
+use Illuminate\Foundation\Application;
+use LogicException;
+use RuntimeException;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Overrides\Auth\BudAuthManager;
+use Sprout\Bud\Overrides\Auth\BudAuthProviderCreator;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Sprout;
+
+/**
+ * @extends \Sprout\Bud\Overrides\BaseOverride<\Illuminate\Auth\AuthManager>
+ */
+final class AuthProviderOverride extends BaseOverride
+{
+    /**
+     * Get the name of the service being overridden.
+     *
+     * @return string
+     */
+    protected function serviceName(): string
+    {
+        return 'auth';
+    }
+
+    /**
+     * Add a driver to the service.
+     *
+     * @param object                               $service
+     * @param \Sprout\Bud\Bud                      $bud
+     * @param \Sprout\Sprout                       $sprout
+     * @param \Closure                             $tracker
+     *
+     * @phpstan-param \Illuminate\Auth\AuthManager $service
+     *
+     * @return void
+     */
+    protected function addDriver(object $service, Bud $bud, Sprout $sprout, Closure $tracker): void
+    {
+        if (! $service instanceof BudAuthManager) {
+            throw new LogicException('Cannot override auth providers without the Bud auth manager override');
+        }
+
+        $service->provider('bud', function (Application $app, array $config) use ($service, $bud, $sprout, $tracker) {
+            /**
+             * @var array<string, mixed>&array{budStore?:string|null,driver:string,provider?:mixed} $config
+             */
+
+            if (! isset($config['provider']) || ! is_string($config['provider']) || $config['provider'] === '') {
+                throw new RuntimeException('Cannot create an auth provider using bud without a name'); // @codeCoverageIgnore
+            }
+
+            $tracker($config['provider']);
+
+            return (new BudAuthProviderCreator($service, $bud, $sprout, $config['provider'], $config))();
+        });
+    }
+
+    /**
+     * Clean up the service override
+     *
+     * This method should perform any necessary setup actions for the service
+     * override.
+     * It is called when the current tenant is unset, either to be replaced
+     * by another tenant, or none.
+     *
+     * It will be called before {@see self::setup()}, but only if the previous
+     * tenant was not null.
+     *
+     * @template TenantClass of \Sprout\Contracts\Tenant
+     *
+     * @param \Sprout\Contracts\Tenancy<TenantClass> $tenancy
+     * @param \Sprout\Contracts\Tenant               $tenant
+     *
+     * @phpstan-param TenantClass                    $tenant
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function cleanup(Tenancy $tenancy, Tenant $tenant): void
+    {
+        if ($this->getApp()->resolved($this->serviceName())) {
+            /** @var \Illuminate\Auth\AuthManager $service */
+            $service = $this->getApp()->make('auth');
+
+            // Providers cannot be cleaned up in the same way as other services,
+            // so we just forget ALL guards, because one or two may have been
+            // using the custom provider.
+            $service->forgetGuards();
+
+            $this->overrides = [];
+        }
+    }
+
+
+    /**
+     * Clean-up an overridden service.
+     *
+     * @param object                               $service
+     * @param string                               $name
+     *
+     * @phpstan-param \Illuminate\Auth\AuthManager $service
+     *
+     * @return void
+     *
+     * @codeCoverageIgnore
+     */
+    protected function cleanupOverride(object $service, string $name): void
+    {
+    }
+}

--- a/src/Overrides/BaseCreator.php
+++ b/src/Overrides/BaseCreator.php
@@ -50,7 +50,7 @@ abstract class BaseCreator
 
         // Get the default store, or the one specified in the config, if there
         // is one.
-        $store = $bud->store($this->config['budStore'] ?? null);
+        $store = $bud->store($config['budStore'] ?? null);
 
         // Get the config for the connection from the store.
         $budConfig = $store->get(

--- a/src/Overrides/BaseCreator.php
+++ b/src/Overrides/BaseCreator.php
@@ -5,6 +5,7 @@ namespace Sprout\Bud\Overrides;
 
 use RuntimeException;
 use Sprout\Bud\Bud;
+use Sprout\Bud\Exceptions\CyclicOverrideException;
 use Sprout\Exceptions\TenancyMissingException;
 use Sprout\Exceptions\TenantMissingException;
 use Sprout\Sprout;
@@ -72,5 +73,22 @@ abstract class BaseCreator
         }
 
         return array_merge($config, $budConfig);
+    }
+
+    /**
+     * Check if the driver is cyclic.
+     *
+     * @param string|null $driver
+     * @param string      $term
+     * @param string      $name
+     *
+     * @return void
+     *
+     */
+    protected function checkForCyclicDrivers(?string $driver, string $term, string $name): void
+    {
+        if ($driver === 'bud') {
+            throw CyclicOverrideException::make($term, $name);
+        }
     }
 }

--- a/src/Overrides/BaseCreator.php
+++ b/src/Overrides/BaseCreator.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides;
+
+use RuntimeException;
+use Sprout\Bud\Bud;
+use Sprout\Exceptions\TenancyMissingException;
+use Sprout\Exceptions\TenantMissingException;
+use Sprout\Sprout;
+
+abstract class BaseCreator
+{
+    /**
+     * @param \Sprout\Sprout                                    $sprout
+     * @param \Sprout\Bud\Bud                                   $bud
+     * @param array<string, mixed>&array{budStore?:string|null} $config
+     * @param string                                            $name
+     *
+     * @return array<string, mixed>
+     *
+     * @throws \Sprout\Exceptions\MisconfigurationException
+     * @throws \Sprout\Exceptions\TenancyMissingException
+     * @throws \Sprout\Exceptions\TenantMissingException
+     */
+    public function getConfig(Sprout $sprout, Bud $bud, array $config, string $name): array
+    {
+        // If we're not within a multitenanted context, we need to error
+        // out, as this driver shouldn't be hit without one
+        if (! $sprout->withinContext()) {
+            throw TenancyMissingException::make();
+        }
+
+        // Get the current active tenancy
+        $tenancy = $sprout->getCurrentTenancy();
+
+        // If there isn't one, that's an issue as we need a tenancy
+        if ($tenancy === null) {
+            throw TenancyMissingException::make();
+        }
+
+        // If there is a tenancy, but it doesn't have a tenant, that's also
+        // an issue
+        if ($tenancy->check() === false) {
+            throw TenantMissingException::make($tenancy->getName());
+        }
+
+        /** @var \Sprout\Contracts\Tenant $tenant */
+        $tenant = $tenancy->tenant();
+
+        // Get the default store, or the one specified in the config, if there
+        // is one.
+        $store = $bud->store($this->config['budStore'] ?? null);
+
+        // Get the config for the connection from the store.
+        $budConfig = $store->get(
+            $tenancy,
+            $tenant,
+            'database',
+            $name,
+        );
+
+        // If there isn't any config, it's an error.
+        if ($budConfig === null) {
+            // TODO: Throw a better exception
+            throw new RuntimeException(sprintf(
+                'Unable to find database configuration for connection [%s] for tenant [%s] on tenancy [%s]',
+                $name,
+                $tenant->getTenantIdentifier(),
+                $tenancy->getName()
+            ));
+        }
+
+        return array_merge($config, $budConfig);
+    }
+}

--- a/src/Overrides/BaseCreator.php
+++ b/src/Overrides/BaseCreator.php
@@ -13,6 +13,13 @@ use Sprout\Sprout;
 abstract class BaseCreator
 {
     /**
+     * Get the name of the service for the creator.
+     *
+     * @return string
+     */
+    abstract protected function getService(): string;
+
+    /**
      * @param \Sprout\Sprout                                    $sprout
      * @param \Sprout\Bud\Bud                                   $bud
      * @param array<string, mixed>&array{budStore?:string|null} $config
@@ -53,11 +60,13 @@ abstract class BaseCreator
         // is one.
         $store = $bud->store($config['budStore'] ?? null);
 
+        $service = $this->getService();
+
         // Get the config for the connection from the store.
         $budConfig = $store->get(
             $tenancy,
             $tenant,
-            'database',
+            $service,
             $name,
         );
 
@@ -65,8 +74,8 @@ abstract class BaseCreator
         if ($budConfig === null) {
             // TODO: Throw a better exception
             throw new RuntimeException(sprintf(
-                'Unable to find database configuration for connection [%s] for tenant [%s] on tenancy [%s]',
-                $name,
+                'Unable to find configuration for [%s] for tenant [%s] on tenancy [%s]',
+                $service . '.' . $name,
                 $tenant->getTenantIdentifier(),
                 $tenancy->getName()
             ));

--- a/src/Overrides/BaseOverride.php
+++ b/src/Overrides/BaseOverride.php
@@ -113,7 +113,7 @@ abstract class BaseOverride extends SproutBaseOverride
     public function cleanup(Tenancy $tenancy, Tenant $tenant): void
     {
         if ($this->tracksOverrides === false) {
-            return;
+            return; // @codeCoverageIgnore
         }
 
         // If the service was resolved, we need to clear it up.

--- a/src/Overrides/BaseOverride.php
+++ b/src/Overrides/BaseOverride.php
@@ -35,7 +35,7 @@ abstract class BaseOverride extends SproutBaseOverride
      *
      * @return string[]
      */
-    protected function getOverrides(): array
+    public function getOverrides(): array
     {
         return $this->overrides;
     }
@@ -127,6 +127,8 @@ abstract class BaseOverride extends SproutBaseOverride
                 foreach ($overrides as $override) {
                     $this->cleanupOverride($service, $override);
                 }
+
+                $this->overrides = [];
             }
         }
     }

--- a/src/Overrides/BaseOverride.php
+++ b/src/Overrides/BaseOverride.php
@@ -20,7 +20,7 @@ abstract class BaseOverride extends SproutBaseOverride implements BootableServic
     /**
      * @var array<string>
      */
-    private array $overrides = [];
+    protected array $overrides = [];
 
     protected bool $tracksOverrides = true;
 

--- a/src/Overrides/BaseOverride.php
+++ b/src/Overrides/BaseOverride.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides;
+
+use Closure;
+use Illuminate\Contracts\Foundation\Application;
+use Sprout\Bud\Bud;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Overrides\BaseOverride as SproutBaseOverride;
+use Sprout\Sprout;
+
+/**
+ * @template OverrideService of object
+ */
+abstract class BaseOverride extends SproutBaseOverride
+{
+    /**
+     * @var array<string>
+     */
+    private array $overrides = [];
+
+    protected bool $tracksOverrides = true;
+
+    /**
+     * Get the name of the service being overridden.
+     *
+     * @return string
+     */
+    abstract protected function serviceName(): string;
+
+    /**
+     * Get the overridden driver names.
+     *
+     * @return string[]
+     */
+    protected function getOverrides(): array
+    {
+        return $this->overrides;
+    }
+
+    /**
+     * Boot a service override
+     *
+     * This method should perform any initial steps required for the service
+     * override that take place during the booting of the framework.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param \Sprout\Sprout                               $sprout
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function boot(Application $app, Sprout $sprout): void
+    {
+        $tracker = $this->tracksOverrides
+            ? fn (string $name) => $this->overrides[] = $name
+            : static fn () => null;
+
+        if ($app->resolved($this->serviceName())) {
+            /** @var OverrideService $service */
+            $service = $app->make($this->serviceName());
+            $this->addDriver($service, $app->make(Bud::class), $sprout, $tracker);
+        } else {
+            $app->afterResolving(
+                $this->serviceName(),
+                function (object $service, Application $app) use ($sprout, $tracker) {
+                    /** @var OverrideService $service */
+                    $this->addDriver($service, $app->make(Bud::class), $sprout, $tracker);
+                }
+            );
+        }
+    }
+
+    /**
+     * Add a driver to the service.
+     *
+     * @param object                  $service
+     * @param \Sprout\Bud\Bud         $bud
+     * @param \Sprout\Sprout          $sprout
+     * @param \Closure                $tracker
+     *
+     * @phpstan-param OverrideService $service
+     *
+     * @return void
+     */
+    abstract protected function addDriver(object $service, Bud $bud, Sprout $sprout, Closure $tracker): void;
+
+    /**
+     * Clean up the service override
+     *
+     * This method should perform any necessary setup actions for the service
+     * override.
+     * It is called when the current tenant is unset, either to be replaced
+     * by another tenant, or none.
+     *
+     * It will be called before {@see self::setup()}, but only if the previous
+     * tenant was not null.
+     *
+     * @template TenantClass of \Sprout\Contracts\Tenant
+     *
+     * @param \Sprout\Contracts\Tenancy<TenantClass> $tenancy
+     * @param \Sprout\Contracts\Tenant               $tenant
+     *
+     * @phpstan-param TenantClass                    $tenant
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function cleanup(Tenancy $tenancy, Tenant $tenant): void
+    {
+        if ($this->tracksOverrides === false) {
+            return;
+        }
+
+        // If the service was resolved, we need to clear it up.
+        if ($this->getApp()->resolved($this->serviceName())) {
+            $overrides = $this->getOverrides();
+
+            if (! empty($overrides)) {
+                /** @var OverrideService $service */
+                $service = $this->getApp()->make($this->serviceName());
+
+                foreach ($overrides as $override) {
+                    $this->cleanupOverride($service, $override);
+                }
+            }
+        }
+    }
+
+    /**
+     * Clean-up an overridden service.
+     *
+     * @param object                  $service
+     * @param string                  $name
+     *
+     * @phpstan-param OverrideService $service
+     *
+     * @return void
+     */
+    abstract protected function cleanupOverride(object $service, string $name): void;
+}

--- a/src/Overrides/BaseOverride.php
+++ b/src/Overrides/BaseOverride.php
@@ -6,6 +6,7 @@ namespace Sprout\Bud\Overrides;
 use Closure;
 use Illuminate\Contracts\Foundation\Application;
 use Sprout\Bud\Bud;
+use Sprout\Contracts\BootableServiceOverride;
 use Sprout\Contracts\Tenancy;
 use Sprout\Contracts\Tenant;
 use Sprout\Overrides\BaseOverride as SproutBaseOverride;
@@ -14,7 +15,7 @@ use Sprout\Sprout;
 /**
  * @template OverrideService of object
  */
-abstract class BaseOverride extends SproutBaseOverride
+abstract class BaseOverride extends SproutBaseOverride implements BootableServiceOverride
 {
     /**
      * @var array<string>

--- a/src/Overrides/Broadcast/BudBroadcastConnectionCreator.php
+++ b/src/Overrides/Broadcast/BudBroadcastConnectionCreator.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides\Broadcast;
+
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use InvalidArgumentException;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Overrides\BaseCreator;
+use Sprout\Sprout;
+
+/**
+ * Bud Broadcast Connection Creator
+ *
+ * This class is an abstraction for the logic that creates a broadcast connection
+ * using a config store within Bud.
+ */
+final class BudBroadcastConnectionCreator extends BaseCreator
+{
+    private BudBroadcastManager $manager;
+
+    private Bud $bud;
+
+    private Sprout $sprout;
+
+    /**
+     * @var array<string, mixed>&array{budStore?:string|null,name?:mixed}
+     */
+    private array $config;
+
+    /**
+     * @param \Sprout\Bud\Overrides\Broadcast\BudBroadcastManager           $manager
+     * @param \Sprout\Bud\Bud                                               $bud
+     * @param \Sprout\Sprout                                                $sprout
+     * @param array<string, mixed>&array{budStore?:string|null,name?:mixed} $config
+     */
+    public function __construct(
+        BudBroadcastManager $manager,
+        Bud                 $bud,
+        Sprout              $sprout,
+        array               $config
+    )
+    {
+        $this->manager = $manager;
+        $this->bud     = $bud;
+        $this->sprout  = $sprout;
+        $this->config  = $config;
+    }
+
+    /**
+     * Create the connection using Bud.
+     *
+     * @return \Illuminate\Contracts\Broadcasting\Broadcaster
+     *
+     * @throws \Sprout\Exceptions\MisconfigurationException
+     * @throws \Sprout\Exceptions\TenancyMissingException
+     * @throws \Sprout\Exceptions\TenantMissingException
+     */
+    public function __invoke(): Broadcaster
+    {
+        if (! isset($this->config['name']) || ! is_string($this->config['name'])) {
+            throw new InvalidArgumentException('Broadcast connection name must be provided.');
+        }
+
+        /** @var array<string, mixed>&array{driver:string,name:string} $config */
+        $config = $this->getConfig($this->sprout, $this->bud, $this->config, $this->config['name']);
+
+        // We need to make sure that this isn't going to recurse infinitely.
+        $this->checkForCyclicDrivers(
+            $config['driver'],
+            'broadcast connection',
+            $this->config['name']
+        );
+
+        // If we're here, it's not cyclic, so we'll create a dynamic connection,
+        // using the methods from our manager override.
+        return $this->manager->connectUsing(
+            $config['name'],
+            $config,
+            true // This is important, it needs to be here to avoid side-effect errors.
+        );
+    }
+}

--- a/src/Overrides/Broadcast/BudBroadcastConnectionCreator.php
+++ b/src/Overrides/Broadcast/BudBroadcastConnectionCreator.php
@@ -80,4 +80,14 @@ final class BudBroadcastConnectionCreator extends BaseCreator
             true // This is important, it needs to be here to avoid side-effect errors.
         );
     }
+
+    /**
+     * Get the name of the service for the creator.
+     *
+     * @return string
+     */
+    protected function getService(): string
+    {
+        return 'broadcast';
+    }
 }

--- a/src/Overrides/Broadcast/BudBroadcastManager.php
+++ b/src/Overrides/Broadcast/BudBroadcastManager.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides\Broadcast;
+
+use Illuminate\Broadcasting\BroadcastManager;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use InvalidArgumentException;
+
+final class BudBroadcastManager extends BroadcastManager
+{
+    protected bool $syncedFromOriginal = false;
+
+    public function __construct($app, ?BroadcastManager $original = null)
+    {
+        parent::__construct($app);
+
+        if ($original) {
+            $this->syncOriginal($original);
+        }
+    }
+
+    /**
+     * Check if this manager override was synced from the original
+     *
+     * @return bool
+     */
+    public function wasSyncedFromOriginal(): bool
+    {
+        return $this->syncedFromOriginal;
+    }
+
+    /**
+     * Sync the original manager in case things have been registered
+     *
+     * @param \Illuminate\Broadcasting\BroadcastManager $original
+     *
+     * @return void
+     */
+    private function syncOriginal(BroadcastManager $original): void
+    {
+        $this->drivers            = array_merge($original->drivers, $this->drivers);
+        $this->customCreators     = array_merge($original->customCreators, $this->customCreators);
+        $this->syncedFromOriginal = true;
+    }
+
+    /**
+     * Get a driver instance using the given config.
+     *
+     * @param string                                    $name
+     * @param array<string, mixed>&array{driver:string} $config
+     * @param bool                                      $force
+     *
+     * @return \Illuminate\Contracts\Broadcasting\Broadcaster
+     */
+    public function connectUsing(string $name, array $config, bool $force = false): Broadcaster
+    {
+        if ($force) {
+            $this->purge($name);
+        }
+
+        /** @var \Illuminate\Contracts\Broadcasting\Broadcaster */
+        return $this->drivers[$name] ?? ($this->drivers[$name] = $this->resolveUsing($config));
+    }
+
+    /**
+     * Resolve the given broadcaster.
+     *
+     * @param string $name
+     *
+     * @return \Illuminate\Contracts\Broadcasting\Broadcaster
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function resolve($name): Broadcaster
+    {
+        /** @var (array<string, mixed>&array{driver:string})|null $config */
+        $config = $this->getConfig($name);
+
+        if (is_null($config)) {
+            throw new InvalidArgumentException("Broadcast connection [{$name}] is not defined.");
+        }
+
+        $config['name'] = $name;
+
+        return $this->resolveUsing($config);
+    }
+
+    /**
+     * Resolve the given broadcaster.
+     *
+     * @param array<string, mixed>&array{driver:string} $config
+     *
+     * @return \Illuminate\Contracts\Broadcasting\Broadcaster
+     *
+     */
+    public function resolveUsing(array $config): Broadcaster
+    {
+        if (isset($this->customCreators[$config['driver']])) {
+            /** @var \Illuminate\Contracts\Broadcasting\Broadcaster */
+            return $this->callCustomCreator($config);
+        }
+
+        $driverMethod = 'create' . ucfirst($config['driver']) . 'Driver';
+
+        if (! method_exists($this, $driverMethod)) {
+            throw new InvalidArgumentException("Driver [{$config['driver']}] is not supported.");
+        }
+
+        /** @var \Illuminate\Contracts\Broadcasting\Broadcaster */
+        return $this->{$driverMethod}($config);
+    }
+}

--- a/src/Overrides/Broadcast/BudBroadcastManager.php
+++ b/src/Overrides/Broadcast/BudBroadcastManager.php
@@ -7,7 +7,7 @@ use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Contracts\Broadcasting\Broadcaster;
 use InvalidArgumentException;
 
-final class BudBroadcastManager extends BroadcastManager
+class BudBroadcastManager extends BroadcastManager
 {
     protected bool $syncedFromOriginal = false;
 
@@ -59,6 +59,8 @@ final class BudBroadcastManager extends BroadcastManager
             $this->purge($name);
         }
 
+        $config['name'] = $name;
+
         /** @var \Illuminate\Contracts\Broadcasting\Broadcaster */
         return $this->drivers[$name] ?? ($this->drivers[$name] = $this->resolveUsing($config));
     }
@@ -96,6 +98,10 @@ final class BudBroadcastManager extends BroadcastManager
      */
     public function resolveUsing(array $config): Broadcaster
     {
+        if (empty($config['driver'])) {
+            throw new InvalidArgumentException("Broadcast connection [{$config['name']}] does not have a configured driver.");
+        }
+
         if (isset($this->customCreators[$config['driver']])) {
             /** @var \Illuminate\Contracts\Broadcasting\Broadcaster */
             return $this->callCustomCreator($config);

--- a/src/Overrides/Broadcast/BudBroadcastManager.php
+++ b/src/Overrides/Broadcast/BudBroadcastManager.php
@@ -91,7 +91,7 @@ class BudBroadcastManager extends BroadcastManager
     /**
      * Resolve the given broadcaster.
      *
-     * @param array<string, mixed>&array{driver:string} $config
+     * @param array<string, mixed>&array{driver:string,name:string} $config
      *
      * @return \Illuminate\Contracts\Broadcasting\Broadcaster
      *

--- a/src/Overrides/BroadcastConnectionOverride.php
+++ b/src/Overrides/BroadcastConnectionOverride.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides;
+
+use Closure;
+use Illuminate\Broadcasting\BroadcastManager;
+use LogicException;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Overrides\Broadcast\BudBroadcastConnectionCreator;
+use Sprout\Bud\Overrides\Broadcast\BudBroadcastManager;
+use Sprout\Contracts\BootableServiceOverride;
+use Sprout\Sprout;
+
+/**
+ * Broadcast Connection Override
+ *
+ * This override specifically allows for the creation of broadcast connections
+ * using Bud config store.
+ *
+ * @extends \Sprout\Bud\Overrides\BaseOverride<\Illuminate\Broadcasting\BroadcastManager>
+ */
+final class BroadcastConnectionOverride extends BaseOverride implements BootableServiceOverride
+{
+    /**
+     * Get the name of the service being overridden.
+     *
+     * @return string
+     */
+    protected function serviceName(): string
+    {
+        return BroadcastManager::class;
+    }
+
+    /**
+     * Add a driver to the service.
+     *
+     * @param object                                            $service
+     * @param \Sprout\Bud\Bud                                   $bud
+     * @param \Sprout\Sprout                                    $sprout
+     * @param \Closure                                          $tracker
+     *
+     * @phpstan-param \Illuminate\Broadcasting\BroadcastManager $service
+     *
+     * @return void
+     */
+    protected function addDriver(object $service, Bud $bud, Sprout $sprout, Closure $tracker): void
+    {
+        if (! $service instanceof BudBroadcastManager) {
+            throw new LogicException('Cannot override broadcast connections without the Bud broadcast manager override');
+        }
+
+        // Add a bud driver.
+        $service->extend('bud', function (array $config) use ($service, $bud, $sprout, $tracker) {
+            /** @var array<string, mixed>&array{budStore?:string|null,name?:string|null} $config */
+            // If the config contains the disk name
+            if (isset($config['name'])) {
+                // Track it
+                $tracker($config['name']);
+            }
+
+            return (new BudBroadcastConnectionCreator($service, $bud, $sprout, $config))();
+        });
+    }
+
+    /**
+     * Clean-up an overridden service.
+     *
+     * @param object                                            $service
+     * @param string                                            $name
+     *
+     * @phpstan-param \Illuminate\Broadcasting\BroadcastManager $service
+     *
+     * @return void
+     */
+    protected function cleanupOverride(object $service, string $name): void
+    {
+        $service->purge($name);
+    }
+}

--- a/src/Overrides/BroadcastConnectionOverride.php
+++ b/src/Overrides/BroadcastConnectionOverride.php
@@ -10,7 +10,6 @@ use LogicException;
 use Sprout\Bud\Bud;
 use Sprout\Bud\Overrides\Broadcast\BudBroadcastConnectionCreator;
 use Sprout\Bud\Overrides\Broadcast\BudBroadcastManager;
-use Sprout\Contracts\BootableServiceOverride;
 use Sprout\Sprout;
 
 /**
@@ -21,7 +20,7 @@ use Sprout\Sprout;
  *
  * @extends \Sprout\Bud\Overrides\BaseOverride<\Illuminate\Broadcasting\BroadcastManager>
  */
-final class BroadcastConnectionOverride extends BaseOverride implements BootableServiceOverride
+final class BroadcastConnectionOverride extends BaseOverride
 {
     /**
      * Get the name of the service being overridden.

--- a/src/Overrides/BroadcastConnectionOverride.php
+++ b/src/Overrides/BroadcastConnectionOverride.php
@@ -5,6 +5,7 @@ namespace Sprout\Bud\Overrides;
 
 use Closure;
 use Illuminate\Broadcasting\BroadcastManager;
+use Illuminate\Contracts\Foundation\Application;
 use LogicException;
 use Sprout\Bud\Bud;
 use Sprout\Bud\Overrides\Broadcast\BudBroadcastConnectionCreator;
@@ -51,7 +52,7 @@ final class BroadcastConnectionOverride extends BaseOverride implements Bootable
         }
 
         // Add a bud driver.
-        $service->extend('bud', function (array $config) use ($service, $bud, $sprout, $tracker) {
+        $service->extend('bud', function (Application $app, array $config) use ($service, $bud, $sprout, $tracker) {
             /** @var array<string, mixed>&array{budStore?:string|null,name?:string|null} $config */
             // If the config contains the disk name
             if (isset($config['name'])) {

--- a/src/Overrides/BroadcastManagerOverride.php
+++ b/src/Overrides/BroadcastManagerOverride.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides;
+
+use Illuminate\Broadcasting\BroadcastManager;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Foundation\Application;
+use Sprout\Bud\Overrides\Broadcast\BudBroadcastManager;
+use Sprout\Contracts\BootableServiceOverride;
+use Sprout\Overrides\BaseOverride;
+use Sprout\Sprout;
+
+final class BroadcastManagerOverride extends BaseOverride implements BootableServiceOverride
+{
+    /**
+     * Boot a service override
+     *
+     * This method should perform any initial steps required for the service
+     * override that take place during the booting of the framework.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param \Sprout\Sprout                               $sprout
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function boot(Application $app, Sprout $sprout): void
+    {
+        $original = null;
+
+        // If the broadcast manager has already been resolved
+        if ($app->resolved(BroadcastManager::class)) {
+            // We'll grab the manager
+            $original = $app->make(BroadcastManager::class);
+            // and then tell the container to forget it
+            $app->forgetInstance(BroadcastManager::class);
+        }
+
+        // Bind a replacement broadcast manager to enable Bud features
+        $app->singleton(BroadcastManager::class, fn (Container $app) => new BudBroadcastManager($app, $original));
+    }
+}

--- a/src/Overrides/BroadcastManagerOverride.php
+++ b/src/Overrides/BroadcastManagerOverride.php
@@ -7,10 +7,11 @@ use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
 use Sprout\Bud\Overrides\Broadcast\BudBroadcastManager;
+use Sprout\Contracts\BootableServiceOverride;
 use Sprout\Overrides\BaseOverride;
 use Sprout\Sprout;
 
-final class BroadcastManagerOverride extends BaseOverride
+final class BroadcastManagerOverride extends BaseOverride implements BootableServiceOverride
 {
     /**
      * Boot a service override

--- a/src/Overrides/BroadcastManagerOverride.php
+++ b/src/Overrides/BroadcastManagerOverride.php
@@ -7,11 +7,10 @@ use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
 use Sprout\Bud\Overrides\Broadcast\BudBroadcastManager;
-use Sprout\Contracts\BootableServiceOverride;
 use Sprout\Overrides\BaseOverride;
 use Sprout\Sprout;
 
-final class BroadcastManagerOverride extends BaseOverride implements BootableServiceOverride
+final class BroadcastManagerOverride extends BaseOverride
 {
     /**
      * Boot a service override

--- a/src/Overrides/Cache/BudCacheStoreCreator.php
+++ b/src/Overrides/Cache/BudCacheStoreCreator.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides\Cache;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Arr;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Overrides\BaseCreator;
+use Sprout\Sprout;
+
+final class BudCacheStoreCreator extends BaseCreator
+{
+    private CacheManager $manager;
+
+    private Bud $bud;
+
+    private Sprout $sprout;
+
+    private string $name;
+
+    /**
+     * @var array<string, mixed>&array{budStore?:string|null}
+     */
+    private array $config;
+
+    /**
+     * @param \Illuminate\Cache\CacheManager                    $manager
+     * @param \Sprout\Bud\Bud                                   $bud
+     * @param \Sprout\Sprout                                    $sprout
+     * @param string                                            $name
+     * @param array<string, mixed>&array{budStore?:string|null} $config
+     */
+    public function __construct(
+        CacheManager $manager,
+        Bud          $bud,
+        Sprout       $sprout,
+        string       $name,
+        array        $config = []
+    )
+    {
+        $this->manager = $manager;
+        $this->bud     = $bud;
+        $this->sprout  = $sprout;
+        $this->name    = $name;
+        $this->config  = $config;
+    }
+
+    /**
+     * Get the name of the service for the creator.
+     *
+     * @return string
+     */
+    protected function getService(): string
+    {
+        return 'cache';
+    }
+
+    /**
+     * @return \Illuminate\Contracts\Cache\Repository
+     *
+     * @throws \Sprout\Bud\Exceptions\CyclicOverrideException
+     * @throws \Sprout\Exceptions\MisconfigurationException
+     * @throws \Sprout\Exceptions\TenancyMissingException
+     * @throws \Sprout\Exceptions\TenantMissingException
+     */
+    public function __invoke(): Repository
+    {
+        /** @var array<string, mixed>&array{driver:string} $config */
+        $config = $this->getConfig($this->sprout, $this->bud, $this->config, $this->name);
+
+        // We need to make sure that this isn't going to recurse infinitely.
+        $this->checkForCyclicDrivers(
+            $config['driver'],
+            'cache store',
+            $this->name
+        );
+
+        return $this->manager->build(Arr::except($config, ['store']));
+    }
+}

--- a/src/Overrides/CacheStoreOverride.php
+++ b/src/Overrides/CacheStoreOverride.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides;
+
+use Closure;
+use Illuminate\Foundation\Application;
+use RuntimeException;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Overrides\Cache\BudCacheStoreCreator;
+use Sprout\Sprout;
+
+/**
+ * @extends \Sprout\Bud\Overrides\BaseOverride<\Illuminate\Cache\CacheManager>
+ */
+final class CacheStoreOverride extends BaseOverride
+{
+    /**
+     * Get the name of the service being overridden.
+     *
+     * @return string
+     */
+    protected function serviceName(): string
+    {
+        return 'cache';
+    }
+
+    /**
+     * Add a driver to the service.
+     *
+     * @param object                                 $service
+     * @param \Sprout\Bud\Bud                        $bud
+     * @param \Sprout\Sprout                         $sprout
+     * @param \Closure                               $tracker
+     *
+     * @phpstan-param \Illuminate\Cache\CacheManager $service
+     *
+     * @return void
+     */
+    protected function addDriver(object $service, Bud $bud, Sprout $sprout, Closure $tracker): void
+    {
+        $service->extend('bud', function (Application $app, array $config) use ($service, $bud, $sprout, $tracker) {
+            /**
+             * @var array<string, mixed>&array{budStore?:string|null,store:string} $config
+             */
+
+            // Track the cache store name.
+            $tracker($config['store']);
+
+            return (new BudCacheStoreCreator($service, $bud, $sprout, $config['store'], $config))();
+        });
+    }
+
+    /**
+     * Clean-up an overridden service.
+     *
+     * @param object                                 $service
+     * @param string                                 $name
+     *
+     * @phpstan-param \Illuminate\Cache\CacheManager $service
+     *
+     * @return void
+     */
+    protected function cleanupOverride(object $service, string $name): void
+    {
+        $service->purge($name);
+    }
+}

--- a/src/Overrides/Database/BudDatabaseConnectionCreator.php
+++ b/src/Overrides/Database/BudDatabaseConnectionCreator.php
@@ -82,4 +82,14 @@ final class BudDatabaseConnectionCreator extends BaseCreator
             true // This is important, it needs to be here to avoid side-effect errors.
         );
     }
+
+    /**
+     * Get the name of the service for the creator.
+     *
+     * @return string
+     */
+    protected function getService(): string
+    {
+        return 'database';
+    }
 }

--- a/src/Overrides/Database/BudDatabaseConnectionCreator.php
+++ b/src/Overrides/Database/BudDatabaseConnectionCreator.php
@@ -7,6 +7,7 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\DatabaseManager;
 use RuntimeException;
 use Sprout\Bud\Bud;
+use Sprout\Bud\Overrides\BaseCreator;
 use Sprout\Exceptions\TenancyMissingException;
 use Sprout\Exceptions\TenantMissingException;
 use Sprout\Sprout;
@@ -15,9 +16,9 @@ use Sprout\Sprout;
  * Bud Database Connection Creator
  *
  * This class is an abstraction for the logic that creates a database connection
- * using config store within Bud.
+ * using a config store within Bud.
  */
-final class BudDatabaseConnectionCreator
+final class BudDatabaseConnectionCreator extends BaseCreator
 {
     private DatabaseManager $manager;
 
@@ -65,58 +66,22 @@ final class BudDatabaseConnectionCreator
      */
     public function __invoke(): ConnectionInterface
     {
-        // If we're not within a multitenanted context, we need to error
-        // out, as this driver shouldn't be hit without one
-        if (! $this->sprout->withinContext()) {
-            throw TenancyMissingException::make();
-        }
+        $config = $this->getConfig($this->sprout, $this->bud, $this->config, $this->name);
 
-        // Get the current active tenancy
-        $tenancy = $this->sprout->getCurrentTenancy();
-
-        // If there isn't one, that's an issue as we need a tenancy
-        if ($tenancy === null) {
-            throw TenancyMissingException::make();
-        }
-
-        // If there is a tenancy, but it doesn't have a tenant, that's also
-        // an issue
-        if ($tenancy->check() === false) {
-            throw TenantMissingException::make($tenancy->getName());
-        }
-
-        /** @var \Sprout\Contracts\Tenant $tenant */
-        $tenant = $tenancy->tenant();
-
-        // Get the default store, or the one specified in the config, if there
-        // is one.
-        $store  = $this->bud->store($this->config['budStore'] ?? null);
-
-        // Get the config for the connection from the store.
-        $config = $store->get(
-            $tenancy,
-            $tenant,
-            'database',
-            $this->name,
-        );
-
-        // If there isn't any config, it's an error.
-        if ($config === null) {
-            // TODO: Throw a better exception
+        // We need to make sure that this is going to recurse infinitely.
+        if (isset($config['driver']) && $config['driver'] === 'bud') {
             throw new RuntimeException(sprintf(
-                'Unable to find database configuration for connection [%s] for tenant [%s] on tenancy [%s]',
-                $this->name,
-                $tenant->getTenantIdentifier(),
-                $tenancy->getName()
+                'Attempt to create cyclic bud database connection [%s] detected',
+                $this->name
             ));
         }
 
-        // If we're here, it all worked, so we'll create a dynamic connection.
+        // If we're here, it's not cyclic, so we'll create a dynamic connection.
         // We're intentionally not using the methods for creating a dynamic
         // connection because it does funky stuff with the names.
         return $this->manager->connectUsing(
             $this->name,
-            array_merge($this->config, $config),
+            $config,
             true // This is important, it needs to be here to avoid side-effect errors.
         );
     }

--- a/src/Overrides/Database/BudDatabaseConnectionCreator.php
+++ b/src/Overrides/Database/BudDatabaseConnectionCreator.php
@@ -1,0 +1,123 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides\Database;
+
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\DatabaseManager;
+use RuntimeException;
+use Sprout\Bud\Bud;
+use Sprout\Exceptions\TenancyMissingException;
+use Sprout\Exceptions\TenantMissingException;
+use Sprout\Sprout;
+
+/**
+ * Bud Database Connection Creator
+ *
+ * This class is an abstraction for the logic that creates a database connection
+ * using config store within Bud.
+ */
+final class BudDatabaseConnectionCreator
+{
+    private DatabaseManager $manager;
+
+    private Bud $bud;
+
+    private Sprout $sprout;
+
+    private string $name;
+
+    /**
+     * @var array<string, mixed>&array{budStore?:string|null}
+     */
+    private array $config;
+
+    /**
+     * @param \Illuminate\Database\DatabaseManager              $manager
+     * @param \Sprout\Bud\Bud                                   $bud
+     * @param \Sprout\Sprout                                    $sprout
+     * @param string                                            $name
+     * @param array<string, mixed>&array{budStore?:string|null} $config
+     */
+    public function __construct(
+        DatabaseManager $manager,
+        Bud             $bud,
+        Sprout          $sprout,
+        string          $name,
+        array           $config
+    )
+    {
+        $this->manager = $manager;
+        $this->bud     = $bud;
+        $this->sprout  = $sprout;
+        $this->name    = $name;
+        $this->config  = $config;
+    }
+
+    /**
+     * Create the connection using Bud.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     *
+     * @throws \Sprout\Exceptions\MisconfigurationException
+     * @throws \Sprout\Exceptions\TenancyMissingException
+     * @throws \Sprout\Exceptions\TenantMissingException
+     */
+    public function __invoke(): ConnectionInterface
+    {
+        // If we're not within a multitenanted context, we need to error
+        // out, as this driver shouldn't be hit without one
+        if (! $this->sprout->withinContext()) {
+            throw TenancyMissingException::make();
+        }
+
+        // Get the current active tenancy
+        $tenancy = $this->sprout->getCurrentTenancy();
+
+        // If there isn't one, that's an issue as we need a tenancy
+        if ($tenancy === null) {
+            throw TenancyMissingException::make();
+        }
+
+        // If there is a tenancy, but it doesn't have a tenant, that's also
+        // an issue
+        if ($tenancy->check() === false) {
+            throw TenantMissingException::make($tenancy->getName());
+        }
+
+        /** @var \Sprout\Contracts\Tenant $tenant */
+        $tenant = $tenancy->tenant();
+
+        // Get the default store, or the one specified in the config, if there
+        // is one.
+        $store  = $this->bud->store($this->config['budStore'] ?? null);
+
+        // Get the config for the connection from the store.
+        $config = $store->get(
+            $tenancy,
+            $tenant,
+            'database',
+            $this->name,
+        );
+
+        // If there isn't any config, it's an error.
+        if ($config === null) {
+            // TODO: Throw a better exception
+            throw new RuntimeException(sprintf(
+                'Unable to find database configuration for connection [%s] for tenant [%s] on tenancy [%s]',
+                $this->name,
+                $tenant->getTenantIdentifier(),
+                $tenancy->getName()
+            ));
+        }
+
+        // If we're here, it all worked, so we'll create a dynamic connection.
+        // We're intentionally not using the methods for creating a dynamic
+        // connection because it does funky stuff with the names.
+        return $this->manager->connectUsing(
+            $this->name,
+            array_merge($this->config, $config),
+            true // This is important, it needs to be here to avoid side-effect errors.
+        );
+    }
+}

--- a/src/Overrides/DatabaseConnectionOverride.php
+++ b/src/Overrides/DatabaseConnectionOverride.php
@@ -4,14 +4,9 @@ declare(strict_types=1);
 namespace Sprout\Bud\Overrides;
 
 use Closure;
-use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Database\DatabaseManager;
 use Sprout\Bud\Bud;
 use Sprout\Bud\Overrides\Database\BudDatabaseConnectionCreator;
 use Sprout\Contracts\BootableServiceOverride;
-use Sprout\Contracts\Tenancy;
-use Sprout\Contracts\Tenant;
-use Sprout\Overrides\BaseOverride;
 use Sprout\Sprout;
 
 /**
@@ -19,54 +14,37 @@ use Sprout\Sprout;
  *
  * This override specifically allows for the creation of database connections
  * using Bud config store.
+ *
+ * @extends \Sprout\Bud\Overrides\BaseOverride<\Illuminate\Database\DatabaseManager>
  */
 final class DatabaseConnectionOverride extends BaseOverride implements BootableServiceOverride
 {
     /**
-     * @var list<string>
-     */
-    protected array $connections = [];
-
-    /**
-     * Get the resolved Bud connections.
+     * Get the name of the service being overridden.
      *
-     * @return list<string>
+     * @return string
      */
-    public function getConnections(): array
+    protected function serviceName(): string
     {
-        return $this->connections;
+        return 'db';
     }
 
     /**
-     * Boot a service override
+     * Add a driver to the service.
      *
-     * This method should perform any initial steps required for the service
-     * override that take place during the booting of the framework.
-     *
-     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param object                                       $service
+     * @param \Sprout\Bud\Bud                              $bud
      * @param \Sprout\Sprout                               $sprout
+     * @param \Closure                                     $tracker
+     *
+     * @phpstan-param \Illuminate\Database\DatabaseManager $service
      *
      * @return void
-     *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function boot(Application $app, Sprout $sprout): void
-    {
-        $tracker = fn (string $connection) => $this->connections[] = $connection;
-
-        if ($app->resolved('db')) {
-            $this->addDriver($app->make('db'), $app->make(Bud::class), $sprout, $tracker);
-        } else {
-            $app->afterResolving('db', function (DatabaseManager $db, Application $app) use ($sprout, $tracker) {
-                $this->addDriver($db, $app->make(Bud::class), $sprout, $tracker);
-            });
-        }
-    }
-
-    private function addDriver(DatabaseManager $db, Bud $bud, Sprout $sprout, Closure $tracker): void
+    protected function addDriver(object $service, Bud $bud, Sprout $sprout, Closure $tracker): void
     {
         // Add a bud driver.
-        $db->extend('bud', function ($config, $name) use ($db, $bud, $sprout, $tracker) {
+        $service->extend('bud', function ($config, $name) use ($service, $bud, $sprout, $tracker) {
             // Track the connection name.
             $tracker($name);
 
@@ -75,49 +53,22 @@ final class DatabaseConnectionOverride extends BaseOverride implements BootableS
              * @var array<string, mixed>&array{budStore?:string|null} $config
              */
 
-            return (new BudDatabaseConnectionCreator($db, $bud, $sprout, $name, $config))();
+            return (new BudDatabaseConnectionCreator($service, $bud, $sprout, $name, $config))();
         });
     }
 
     /**
-     * Clean up the service override
+     * Clean-up an overridden service.
      *
-     * This method should perform any necessary setup actions for the service
-     * override.
-     * It is called when the current tenant is unset, either to be replaced
-     * by another tenant, or none.
+     * @param object                                       $service
+     * @param string                                       $name
      *
-     * It will be called before {@see self::setup()}, but only if the previous
-     * tenant was not null.
-     *
-     * @template TenantClass of \Sprout\Contracts\Tenant
-     *
-     * @param \Sprout\Contracts\Tenancy<TenantClass> $tenancy
-     * @param \Sprout\Contracts\Tenant               $tenant
-     *
-     * @phpstan-param TenantClass                    $tenant
+     * @phpstan-param \Illuminate\Database\DatabaseManager $service
      *
      * @return void
-     *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function cleanup(Tenancy $tenancy, Tenant $tenant): void
+    protected function cleanupOverride(object $service, string $name): void
     {
-        // If the database manager was resolved, and we resolved bud-specific
-        // connections, we'll tidy up by purging them.
-        if ($this->getApp()->resolved('db')) {
-            $connections = $this->getConnections();
-
-            if (! empty($connections)) {
-                /** @var \Illuminate\Database\DatabaseManager $manager */
-                $manager = $this->getApp()->make('db');
-
-                foreach ($connections as $connection) {
-                    $manager->purge($connection);
-                }
-            }
-        }
+        $service->purge($name);
     }
-
-
 }

--- a/src/Overrides/DatabaseConnectionOverride.php
+++ b/src/Overrides/DatabaseConnectionOverride.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Sprout\Bud\Overrides;
 
 use Closure;
+use Illuminate\Database\Connection;
+use PDO;
 use Sprout\Bud\Bud;
 use Sprout\Bud\Overrides\Database\BudDatabaseConnectionCreator;
 use Sprout\Contracts\BootableServiceOverride;

--- a/src/Overrides/DatabaseConnectionOverride.php
+++ b/src/Overrides/DatabaseConnectionOverride.php
@@ -1,0 +1,117 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Database\DatabaseManager;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Overrides\Database\BudDatabaseConnectionCreator;
+use Sprout\Contracts\BootableServiceOverride;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Overrides\BaseOverride;
+use Sprout\Sprout;
+
+/**
+ * Database Connection Override
+ *
+ * This override specifically allows for the creation of database connections
+ * using Bud config store.
+ */
+final class DatabaseConnectionOverride extends BaseOverride implements BootableServiceOverride
+{
+    /**
+     * @var list<string>
+     */
+    protected array $connections = [];
+
+    /**
+     * Get the resolved Bud connections.
+     *
+     * @return list<string>
+     */
+    public function getConnections(): array
+    {
+        return $this->connections;
+    }
+
+    /**
+     * Boot a service override
+     *
+     * This method should perform any initial steps required for the service
+     * override that take place during the booting of the framework.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param \Sprout\Sprout                               $sprout
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function boot(Application $app, Sprout $sprout): void
+    {
+        $tracker = fn (string $connection) => $this->connections[] = $connection;
+
+        if ($app->resolved('db')) {
+            $this->addDriver($app->make('db'), $app->make(Bud::class), $sprout, $tracker);
+        } else {
+            $app->afterResolving('db', function (DatabaseManager $db, Application $app) use ($sprout, $tracker) {
+                $this->addDriver($db, $app->make(Bud::class), $sprout, $tracker);
+            });
+        }
+    }
+
+    private function addDriver(DatabaseManager $db, Bud $bud, Sprout $sprout, \Closure $tracker): void
+    {
+        // Add a bud driver.
+        $db->extend('bud', function ($config, $name) use ($db, $bud, $sprout, $tracker) {
+            // Track the connection name.
+            $tracker($name);
+
+            return (new BudDatabaseConnectionCreator($db, $bud, $sprout, $name, $config))();
+        });
+    }
+
+    /**
+     * Clean up the service override
+     *
+     * This method should perform any necessary setup actions for the service
+     * override.
+     * It is called when the current tenant is unset, either to be replaced
+     * by another tenant, or none.
+     *
+     * It will be called before {@see self::setup()}, but only if the previous
+     * tenant was not null.
+     *
+     * @template TenantClass of \Sprout\Contracts\Tenant
+     *
+     * @param \Sprout\Contracts\Tenancy<TenantClass> $tenancy
+     * @param \Sprout\Contracts\Tenant               $tenant
+     *
+     * @phpstan-param TenantClass                    $tenant
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function cleanup(Tenancy $tenancy, Tenant $tenant): void
+    {
+        // If the database manager was resolved, and we resolved bud-specific
+        // connections, we'll tidy up by purging them.
+        if ($this->getApp()->resolved('db')) {
+            $connections = $this->getConnections();
+
+            if (! empty($connections)) {
+                /** @var \Illuminate\Database\DatabaseManager $manager */
+                $manager = $this->getApp()->make('db');
+
+                foreach ($connections as $connection) {
+                    $manager->purge($connection);
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/Overrides/DatabaseConnectionOverride.php
+++ b/src/Overrides/DatabaseConnectionOverride.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 namespace Sprout\Bud\Overrides;
 
 use Closure;
-use Illuminate\Database\Connection;
-use PDO;
 use Sprout\Bud\Bud;
 use Sprout\Bud\Overrides\Database\BudDatabaseConnectionCreator;
-use Sprout\Contracts\BootableServiceOverride;
 use Sprout\Sprout;
 
 /**
@@ -19,7 +16,7 @@ use Sprout\Sprout;
  *
  * @extends \Sprout\Bud\Overrides\BaseOverride<\Illuminate\Database\DatabaseManager>
  */
-final class DatabaseConnectionOverride extends BaseOverride implements BootableServiceOverride
+final class DatabaseConnectionOverride extends BaseOverride
 {
     /**
      * Get the name of the service being overridden.

--- a/src/Overrides/DatabaseConnectionOverride.php
+++ b/src/Overrides/DatabaseConnectionOverride.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Sprout\Bud\Overrides;
 
+use Closure;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\DatabaseManager;
 use Sprout\Bud\Bud;
@@ -62,12 +63,17 @@ final class DatabaseConnectionOverride extends BaseOverride implements BootableS
         }
     }
 
-    private function addDriver(DatabaseManager $db, Bud $bud, Sprout $sprout, \Closure $tracker): void
+    private function addDriver(DatabaseManager $db, Bud $bud, Sprout $sprout, Closure $tracker): void
     {
         // Add a bud driver.
         $db->extend('bud', function ($config, $name) use ($db, $bud, $sprout, $tracker) {
             // Track the connection name.
             $tracker($name);
+
+            /**
+             * @var string                                            $name
+             * @var array<string, mixed>&array{budStore?:string|null} $config
+             */
 
             return (new BudDatabaseConnectionCreator($db, $bud, $sprout, $name, $config))();
         });

--- a/src/Overrides/Filesystem/BudFilesystemDiskCreator.php
+++ b/src/Overrides/Filesystem/BudFilesystemDiskCreator.php
@@ -11,9 +11,9 @@ use Sprout\Bud\Overrides\BaseCreator;
 use Sprout\Sprout;
 
 /**
- * Bud Database Connection Creator
+ * Bud Filesystem Disk Creator
  *
- * This class is an abstraction for the logic that creates a database connection
+ * This class is an abstraction for the logic that creates a filesystem disk
  * using a config store within Bud.
  */
 final class BudFilesystemDiskCreator extends BaseCreator

--- a/src/Overrides/Filesystem/BudFilesystemDiskCreator.php
+++ b/src/Overrides/Filesystem/BudFilesystemDiskCreator.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides\Filesystem;
+
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemManager;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Overrides\BaseCreator;
+use Sprout\Sprout;
+
+/**
+ * Bud Database Connection Creator
+ *
+ * This class is an abstraction for the logic that creates a database connection
+ * using a config store within Bud.
+ */
+final class BudFilesystemDiskCreator extends BaseCreator
+{
+    private FilesystemManager $manager;
+
+    private Bud $bud;
+
+    private Sprout $sprout;
+
+    private string $name;
+
+    /**
+     * @var array<string, mixed>&array{budStore?:string|null}
+     */
+    private array $config;
+
+    /**
+     * @param \Illuminate\Filesystem\FilesystemManager          $manager
+     * @param \Sprout\Bud\Bud                                   $bud
+     * @param \Sprout\Sprout                                    $sprout
+     * @param string                                            $name
+     * @param array<string, mixed>&array{budStore?:string|null} $config
+     */
+    public function __construct(
+        FilesystemManager $manager,
+        Bud               $bud,
+        Sprout            $sprout,
+        string            $name,
+        array             $config
+    )
+    {
+        $this->manager = $manager;
+        $this->bud     = $bud;
+        $this->sprout  = $sprout;
+        $this->name    = $name;
+        $this->config  = $config;
+    }
+
+    /**
+     * Create the connection using Bud.
+     *
+     * @return \Illuminate\Contracts\Filesystem\Filesystem
+     *
+     * @throws \Sprout\Exceptions\MisconfigurationException
+     * @throws \Sprout\Exceptions\TenancyMissingException
+     * @throws \Sprout\Exceptions\TenantMissingException
+     */
+    public function __invoke(): Filesystem
+    {
+        /** @var array<string, mixed>&array{driver?:string|null} $config */
+        $config = $this->getConfig($this->sprout, $this->bud, $this->config, $this->name);
+
+        // We need to make sure that this isn't going to recurse infinitely.
+        $this->checkForCyclicDrivers(
+            $config['driver'] ?? null,
+            'filesystem disk',
+            $this->name
+        );
+
+        return $this->manager->build(
+            array_merge([
+                'name' => $this->name,
+            ], $config)
+        );
+    }
+
+    /**
+     * Get the name of the service for the creator.
+     *
+     * @return string
+     */
+    protected function getService(): string
+    {
+        return 'filesystem';
+    }
+}

--- a/src/Overrides/FilesystemDiskOverride.php
+++ b/src/Overrides/FilesystemDiskOverride.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides;
+
+use Closure;
+use Illuminate\Contracts\Foundation\Application;
+use LogicException;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Overrides\Broadcast\BudBroadcastManager;
+use Sprout\Bud\Overrides\Filesystem\BudFilesystemDiskCreator;
+use Sprout\Contracts\BootableServiceOverride;
+use Sprout\Overrides\Filesystem\SproutFilesystemManager;
+use Sprout\Sprout;
+
+/**
+ * Database Connection Override
+ *
+ * This override specifically allows for the creation of database connections
+ * using Bud config store.
+ *
+ * @extends \Sprout\Bud\Overrides\BaseOverride<\Illuminate\Filesystem\FilesystemManager>
+ */
+final class FilesystemDiskOverride extends BaseOverride implements BootableServiceOverride
+{
+    /**
+     * Get the name of the service being overridden.
+     *
+     * @return string
+     */
+    protected function serviceName(): string
+    {
+        return 'filesystem';
+    }
+
+    /**
+     * Add a driver to the service.
+     *
+     * @param object                                           $service
+     * @param \Sprout\Bud\Bud                                  $bud
+     * @param \Sprout\Sprout                                   $sprout
+     * @param \Closure                                         $tracker
+     *
+     * @phpstan-param \Illuminate\Filesystem\FilesystemManager $service
+     *
+     * @return void
+     */
+    protected function addDriver(object $service, Bud $bud, Sprout $sprout, Closure $tracker): void
+    {
+        if (! $service instanceof SproutFilesystemManager) {
+            throw new LogicException('Cannot override filesystem disks without the Sprout filesystem manager override');
+        }
+
+        // Add a bud driver.
+        $service->extend('bud', function (Application $app, array $config) use ($service, $bud, $sprout, $tracker) {
+            // Track the connection name.
+            /** @var array<string, mixed>&array{budStore?:string|null,name?:string|null} $config */
+            // If the config contains the disk name
+            if (isset($config['name'])) {
+                // Track it
+                $tracker($config['name']);
+            }
+
+            return (new BudFilesystemDiskCreator($service, $bud, $sprout, $config['name'], $config))();
+        });
+    }
+
+    /**
+     * Clean-up an overridden service.
+     *
+     * @param object                                           $service
+     * @param string                                           $name
+     *
+     * @phpstan-param \Illuminate\Filesystem\FilesystemManager $service
+     *
+     * @return void
+     */
+    protected function cleanupOverride(object $service, string $name): void
+    {
+        $service->purge($name);
+    }
+}

--- a/src/Overrides/FilesystemDiskOverride.php
+++ b/src/Overrides/FilesystemDiskOverride.php
@@ -61,7 +61,7 @@ final class FilesystemDiskOverride extends BaseOverride implements BootableServi
                 $tracker($config['name']);
             }
 
-            return (new BudFilesystemDiskCreator($service, $bud, $sprout, $config['name'], $config))();
+            return (new BudFilesystemDiskCreator($service, $bud, $sprout, $config))();
         });
     }
 

--- a/src/Overrides/FilesystemDiskOverride.php
+++ b/src/Overrides/FilesystemDiskOverride.php
@@ -7,9 +7,7 @@ use Closure;
 use Illuminate\Contracts\Foundation\Application;
 use LogicException;
 use Sprout\Bud\Bud;
-use Sprout\Bud\Overrides\Broadcast\BudBroadcastManager;
 use Sprout\Bud\Overrides\Filesystem\BudFilesystemDiskCreator;
-use Sprout\Contracts\BootableServiceOverride;
 use Sprout\Overrides\Filesystem\SproutFilesystemManager;
 use Sprout\Sprout;
 
@@ -21,7 +19,7 @@ use Sprout\Sprout;
  *
  * @extends \Sprout\Bud\Overrides\BaseOverride<\Illuminate\Filesystem\FilesystemManager>
  */
-final class FilesystemDiskOverride extends BaseOverride implements BootableServiceOverride
+final class FilesystemDiskOverride extends BaseOverride
 {
     /**
      * Get the name of the service being overridden.

--- a/src/Overrides/FilesystemDiskOverride.php
+++ b/src/Overrides/FilesystemDiskOverride.php
@@ -12,10 +12,10 @@ use Sprout\Overrides\Filesystem\SproutFilesystemManager;
 use Sprout\Sprout;
 
 /**
- * Database Connection Override
+ * Filesystem Disk Override
  *
- * This override specifically allows for the creation of database connections
- * using Bud config store.
+ * This override specifically allows for the creation of filesystem disks
+ * using the Bud config store.
  *
  * @extends \Sprout\Bud\Overrides\BaseOverride<\Illuminate\Filesystem\FilesystemManager>
  */

--- a/src/Overrides/Mailer/BudMailerTransportCreator.php
+++ b/src/Overrides/Mailer/BudMailerTransportCreator.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Sprout\Bud\Overrides\Mailer;
 
+use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Mail\MailManager;
 use Sprout\Bud\Bud;
 use Sprout\Bud\Overrides\BaseCreator;
@@ -80,6 +81,6 @@ final class BudMailerTransportCreator extends BaseCreator
      */
     protected function getService(): string
     {
-        return 'broadcast';
+        return BroadcastManager::class;
     }
 }

--- a/src/Overrides/Mailer/BudMailerTransportCreator.php
+++ b/src/Overrides/Mailer/BudMailerTransportCreator.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Sprout\Bud\Overrides\Mailer;
 
-use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Mail\MailManager;
 use Sprout\Bud\Bud;
 use Sprout\Bud\Overrides\BaseCreator;

--- a/src/Overrides/Mailer/BudMailerTransportCreator.php
+++ b/src/Overrides/Mailer/BudMailerTransportCreator.php
@@ -61,15 +61,15 @@ final class BudMailerTransportCreator extends BaseCreator
      */
     public function __invoke(): TransportInterface
     {
+        /** @var array<string, mixed>&array{transport?:string|null} $config */
         $config = $this->getConfig($this->sprout, $this->bud, $this->config, $this->name);
 
-        // We need to make sure that this is going to recurse infinitely.
-        if (isset($config['transport']) && $config['transport'] === 'bud') {
-            throw new RuntimeException(sprintf(
-                'Attempt to create cyclic bud mailer [%s] detected',
-                $this->name
-            ));
-        }
+        // We need to make sure that this isn't going to recurse infinitely.
+        $this->checkForCyclicDrivers(
+            $config['transport'] ?? null,
+            'mailer',
+            $this->name
+        );
 
         return $this->manager->createSymfonyTransport($config);
     }

--- a/src/Overrides/Mailer/BudMailerTransportCreator.php
+++ b/src/Overrides/Mailer/BudMailerTransportCreator.php
@@ -34,6 +34,7 @@ final class BudMailerTransportCreator extends BaseCreator
      * @param \Illuminate\Mail\MailManager                      $manager
      * @param \Sprout\Bud\Bud                                   $bud
      * @param \Sprout\Sprout                                    $sprout
+     * @param string                                            $name
      * @param array<string, mixed>&array{budStore?:string|null} $config
      */
     public function __construct(

--- a/src/Overrides/Mailer/BudMailerTransportCreator.php
+++ b/src/Overrides/Mailer/BudMailerTransportCreator.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides\Mailer;
+
+use Illuminate\Mail\MailManager;
+use RuntimeException;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Overrides\BaseCreator;
+use Sprout\Sprout;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+/**
+ * Bud Mailer Transport Creator
+ *
+ * This class is an abstraction for the logic that creates a mailer
+ * using a config store within Bud.
+ */
+final class BudMailerTransportCreator extends BaseCreator
+{
+    private MailManager $manager;
+
+    private Bud $bud;
+
+    private Sprout $sprout;
+
+    private string $name;
+
+    /**
+     * @var array<string, mixed>&array{budStore?:string|null}
+     */
+    private array $config;
+
+    /**
+     * @param \Illuminate\Mail\MailManager                      $manager
+     * @param \Sprout\Bud\Bud                                   $bud
+     * @param \Sprout\Sprout                                    $sprout
+     * @param array<string, mixed>&array{budStore?:string|null} $config
+     */
+    public function __construct(
+        MailManager $manager,
+        Bud         $bud,
+        Sprout      $sprout,
+        string      $name,
+        array       $config = []
+    )
+    {
+        $this->manager = $manager;
+        $this->bud     = $bud;
+        $this->sprout  = $sprout;
+        $this->name    = $name;
+        $this->config  = $config;
+    }
+
+    /**
+     * @return \Symfony\Component\Mailer\Transport\TransportInterface
+     *
+     * @throws \Sprout\Exceptions\MisconfigurationException
+     * @throws \Sprout\Exceptions\TenancyMissingException
+     * @throws \Sprout\Exceptions\TenantMissingException
+     */
+    public function __invoke(): TransportInterface
+    {
+        $config = $this->getConfig($this->sprout, $this->bud, $this->config, $this->name);
+
+        // We need to make sure that this is going to recurse infinitely.
+        if (isset($config['transport']) && $config['transport'] === 'bud') {
+            throw new RuntimeException(sprintf(
+                'Attempt to create cyclic bud mailer [%s] detected',
+                $this->name
+            ));
+        }
+
+        return $this->manager->createSymfonyTransport($config);
+    }
+}

--- a/src/Overrides/Mailer/BudMailerTransportCreator.php
+++ b/src/Overrides/Mailer/BudMailerTransportCreator.php
@@ -81,6 +81,6 @@ final class BudMailerTransportCreator extends BaseCreator
      */
     protected function getService(): string
     {
-        return BroadcastManager::class;
+        return 'mailer';
     }
 }

--- a/src/Overrides/Mailer/BudMailerTransportCreator.php
+++ b/src/Overrides/Mailer/BudMailerTransportCreator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Sprout\Bud\Overrides\Mailer;
 
 use Illuminate\Mail\MailManager;
-use RuntimeException;
 use Sprout\Bud\Bud;
 use Sprout\Bud\Overrides\BaseCreator;
 use Sprout\Sprout;
@@ -72,5 +71,15 @@ final class BudMailerTransportCreator extends BaseCreator
         );
 
         return $this->manager->createSymfonyTransport($config);
+    }
+
+    /**
+     * Get the name of the service for the creator.
+     *
+     * @return string
+     */
+    protected function getService(): string
+    {
+        return 'broadcast';
     }
 }

--- a/src/Overrides/MailerOverride.php
+++ b/src/Overrides/MailerOverride.php
@@ -1,0 +1,123 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Overrides;
+
+use Closure;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Mail\MailManager;
+use RuntimeException;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Overrides\Mailer\BudMailerTransportCreator;
+use Sprout\Contracts\BootableServiceOverride;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Overrides\BaseOverride;
+use Sprout\Sprout;
+
+/**
+ * Mailer Override
+ *
+ * This override specifically allows for the creation of mailers
+ * using Bud config stores.
+ */
+final class MailerOverride extends BaseOverride implements BootableServiceOverride
+{
+    /**
+     * @var list<string>
+     */
+    protected array $mailers = [];
+
+    /**
+     * Get the resolved Bud mailers.
+     *
+     * @return list<string>
+     */
+    public function getMailers(): array
+    {
+        return $this->mailers;
+    }
+
+    /**
+     * Boot a service override
+     *
+     * This method should perform any initial steps required for the service
+     * override that take place during the booting of the framework.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param \Sprout\Sprout                               $sprout
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function boot(Application $app, Sprout $sprout): void
+    {
+        $tracker = fn (string $mailer) => $this->mailers[] = $mailer;
+
+        if ($app->resolved('mail.manager')) {
+            $this->addDriver($app->make('mail.manager'), $app->make(Bud::class), $sprout, $tracker);
+        } else {
+            $app->afterResolving('mail.manager', function (MailManager $mail, Application $app) use ($sprout, $tracker) {
+                $this->addDriver($mail, $app->make(Bud::class), $sprout, $tracker);
+            });
+        }
+    }
+
+    private function addDriver(MailManager $mail, Bud $bud, Sprout $sprout, Closure $tracker): void
+    {
+        // Add a bud driver.
+        $mail->extend('bud', function ($config) use ($mail, $bud, $sprout, $tracker) {
+            if (! isset($config['name'])) {
+                throw new RuntimeException('Cannot create a mailer using bud without a name');
+            }
+
+            // Track the mailer name.
+            $tracker($config['name']);
+
+            return (new BudMailerTransportCreator($mail, $bud, $sprout, $config['name'], $config))();
+        });
+    }
+
+    /**
+     * Clean up the service override
+     *
+     * This method should perform any necessary setup actions for the service
+     * override.
+     * It is called when the current tenant is unset, either to be replaced
+     * by another tenant, or none.
+     *
+     * It will be called before {@see self::setup()}, but only if the previous
+     * tenant was not null.
+     *
+     * @template TenantClass of \Sprout\Contracts\Tenant
+     *
+     * @param \Sprout\Contracts\Tenancy<TenantClass> $tenancy
+     * @param \Sprout\Contracts\Tenant               $tenant
+     *
+     * @phpstan-param Tenant                         $tenant
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function cleanup(Tenancy $tenancy, Tenant $tenant): void
+    {
+        // If the mail manager was resolved, and we resolved bud-specific
+        // mailers, we'll tidy up by purging them.
+        if ($this->getApp()->resolved('mail.manager')) {
+            $mailers = $this->getMailers();
+
+            if (! empty($mailers)) {
+                /** @var \Illuminate\Mail\MailManager $manager */
+                $manager = $this->getApp()->make('mail.manager');
+
+                foreach ($mailers as $mailer) {
+                    $manager->purge($mailer);
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/Overrides/MailerOverride.php
+++ b/src/Overrides/MailerOverride.php
@@ -7,7 +7,6 @@ use Closure;
 use RuntimeException;
 use Sprout\Bud\Bud;
 use Sprout\Bud\Overrides\Mailer\BudMailerTransportCreator;
-use Sprout\Contracts\BootableServiceOverride;
 use Sprout\Sprout;
 
 /**
@@ -18,7 +17,7 @@ use Sprout\Sprout;
  *
  * @extends \Sprout\Bud\Overrides\BaseOverride<\Illuminate\Mail\MailManager>
  */
-final class MailerOverride extends BaseOverride implements BootableServiceOverride
+final class MailerOverride extends BaseOverride
 {
     /**
      * Get the name of the service being overridden.

--- a/src/Overrides/MailerOverride.php
+++ b/src/Overrides/MailerOverride.php
@@ -50,7 +50,7 @@ final class MailerOverride extends BaseOverride
              */
 
             if (! isset($config['name']) || ! is_string($config['name']) || $config['name'] === '') {
-                throw new RuntimeException('Cannot create a mailer using bud without a name');
+                throw new RuntimeException('Cannot create a mailer using bud without a name'); // @codeCoverageIgnore
             }
 
             // Track the mailer name.

--- a/src/Overrides/MailerOverride.php
+++ b/src/Overrides/MailerOverride.php
@@ -68,7 +68,11 @@ final class MailerOverride extends BaseOverride implements BootableServiceOverri
     {
         // Add a bud driver.
         $mail->extend('bud', function ($config) use ($mail, $bud, $sprout, $tracker) {
-            if (! isset($config['name'])) {
+            /**
+             * @var array<string, mixed>&array{budStore?:string|null,name?:mixed} $config
+             */
+
+            if (! isset($config['name']) || ! is_string($config['name']) || $config['name'] === '') {
                 throw new RuntimeException('Cannot create a mailer using bud without a name');
             }
 

--- a/tests/Unit/Overrides/Auth/BudAuthManagerCreatorTest.php
+++ b/tests/Unit/Overrides/Auth/BudAuthManagerCreatorTest.php
@@ -1,0 +1,217 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Tests\Unit\Overrides\Auth;
+
+use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Illuminate\Foundation\Application;
+use InvalidArgumentException;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Contracts\ConfigStore;
+use Sprout\Bud\Managers\ConfigStoreManager;
+use Sprout\Bud\Overrides\Auth\BudAuthManager;
+use Sprout\Bud\Overrides\Auth\BudAuthProviderCreator;
+use Sprout\Bud\Tests\Unit\UnitTestCase;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Contracts\TenantHasResources;
+use Sprout\Exceptions\TenancyMissingException;
+use Sprout\Exceptions\TenantMissingException;
+use Sprout\Sprout;
+use Sprout\Support\SettingsRepository;
+
+class BudAuthManagerCreatorTest extends UnitTestCase
+{
+    private function mockApplication(bool $default = false): Application&Mockery\MockInterface
+    {
+        return Mockery::mock(Application::class, static function (Mockery\MockInterface $mock) use ($default) {
+            $mock->shouldIgnoreMissing();
+        });
+    }
+
+    private function mockManager(bool $driver = true): BudAuthManager&Mockery\MockInterface
+    {
+        return Mockery::mock(BudAuthManager::class, static function (Mockery\MockInterface $mock) use ($driver) {
+            if ($driver) {
+                $mock->shouldReceive('createUserProviderFromConfig')
+                     ->with(
+                         ['provider' => 'fake-provider', 'driver' => 'null'],
+                     )
+                     ->andReturn(Mockery::mock(UserProvider::class))
+                     ->once();
+            }
+        });
+    }
+
+    private function mockConfigStoreManager(?Tenancy $tenancy = null, ?Tenant $tenant = null): ConfigStoreManager&Mockery\MockInterface
+    {
+        return Mockery::mock(ConfigStoreManager::class, static function (Mockery\MockInterface $mock) use ($tenancy, $tenant) {
+            if ($tenancy && $tenant) {
+                $mock->shouldReceive('get')
+                     ->with(null)
+                     ->andReturn(Mockery::mock(ConfigStore::class, static function (Mockery\MockInterface $mock) use ($tenancy, $tenant) {
+                         $mock->shouldReceive('get')
+                              ->with(
+                                  $tenancy,
+                                  $tenant,
+                                  'auth',
+                                  'fake-provider'
+                              )
+                              ->andReturn([
+                                  'driver' => 'null',
+                              ])
+                              ->once();
+                     }))
+                     ->once();
+            }
+        });
+    }
+
+    private function getSprout(Application $app, bool $withTenancy = true, bool $withTenant = true, bool $withResources = true): Sprout
+    {
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        if ($withTenant) {
+            if ($withResources) {
+                $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (Mockery\MockInterface $mock) {
+                });
+            } else {
+                $tenant = Mockery::mock(Tenant::class);
+            }
+
+
+        } else {
+            $tenant = null;
+        }
+
+        if ($withTenancy) {
+            $sprout->setCurrentTenancy(Mockery::mock(Tenancy::class, static function (Mockery\MockInterface $mock) use ($tenant, $withTenant) {
+                $mock->shouldReceive('check')->andReturn($withTenant)->once();
+
+                if ($withTenant) {
+                    $mock->shouldReceive('tenant')->andReturn($tenant)->twice();
+                } else {
+                    $mock->shouldReceive('getName')->andReturn('my-tenancy')->once();
+                }
+            }));
+        }
+
+        return $sprout;
+    }
+
+    private function getBud(Application $app, ConfigStoreManager $manager): Bud
+    {
+        return new Bud($app, $manager);
+    }
+
+    #[Test]
+    public function canCreateTheDriver(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager();
+        $config  = [
+            'provider' => 'fake-provider',
+            'driver'   => 'fake-driver',
+        ];
+        $sprout  = $this->getSprout($app);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager($sprout->getCurrentTenancy(), $sprout->getCurrentTenancy()->tenant()));
+
+        $creator = new BudAuthProviderCreator(
+            $manager,
+            $bud,
+            $sprout,
+            'fake-provider',
+            $config,
+        );
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenOutsideOfContext(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [
+            'provider' => 'fake-provider',
+        ];
+        $sprout  = $this->getSprout($app, false, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $sprout->markAsOutsideContext();
+
+        $this->assertFalse($sprout->withinContext());
+
+        $creator = new BudAuthProviderCreator(
+            $manager,
+            $bud,
+            $sprout,
+            'fake-provider',
+            $config
+        );
+
+        $this->expectException(TenancyMissingException::class);
+        $this->expectExceptionMessage('There is no current tenancy');
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenThereIsNoTenancy(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [
+            'provider' => 'fake-provider',
+        ];
+        $sprout  = $this->getSprout($app, false, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $sprout->markAsInContext();
+
+        $this->assertTrue($sprout->withinContext());
+
+        $creator = new BudAuthProviderCreator(
+            $manager,
+            $bud,
+            $sprout,
+            'fake-provider',
+            $config
+        );
+
+        $this->expectException(TenancyMissingException::class);
+        $this->expectExceptionMessage('There is no current tenancy');
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenThereIsNoTenant(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [
+            'provider' => 'fake-provider',
+        ];
+        $sprout  = $this->getSprout($app, true, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $this->assertTrue($sprout->withinContext());
+
+        $creator = new BudAuthProviderCreator(
+            $manager,
+            $bud,
+            $sprout,
+            'fake-provider',
+            $config
+        );
+
+        $this->expectException(TenantMissingException::class);
+        $this->expectExceptionMessage('There is no current tenant for tenancy [my-tenancy]');
+
+        $creator();
+    }
+}

--- a/tests/Unit/Overrides/Auth/BudAuthManagerCreatorTest.php
+++ b/tests/Unit/Overrides/Auth/BudAuthManagerCreatorTest.php
@@ -81,8 +81,6 @@ class BudAuthManagerCreatorTest extends UnitTestCase
             } else {
                 $tenant = Mockery::mock(Tenant::class);
             }
-
-
         } else {
             $tenant = null;
         }

--- a/tests/Unit/Overrides/Auth/BudAuthManagerTest.php
+++ b/tests/Unit/Overrides/Auth/BudAuthManagerTest.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Tests\Unit\Overrides\Auth;
+
+use Illuminate\Auth\AuthManager;
+use Illuminate\Auth\EloquentUserProvider;
+use Illuminate\Broadcasting\Broadcasters\NullBroadcaster;
+use Illuminate\Broadcasting\BroadcastManager;
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Illuminate\Foundation\Application;
+use InvalidArgumentException;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Bud\Overrides\Auth\BudAuthManager;
+use Sprout\Bud\Overrides\Broadcast\BudBroadcastManager;
+use Sprout\Bud\Tests\Unit\UnitTestCase;
+
+class BudAuthManagerTest extends UnitTestCase
+{
+    #[Test]
+    public function canBeSyncedFromOriginal(): void
+    {
+        $original = Mockery::mock(AuthManager::class);
+
+        $app = Mockery::mock(Application::class);
+
+        $sprout = new BudAuthManager($app, $original);
+
+        $this->assertTrue($sprout->wasSyncedFromOriginal());
+    }
+
+    #[Test]
+    public function addsNameWhenResolvingDriver(): void
+    {
+        $app = Mockery::mock(Application::class, static function (Mockery\MockInterface $mock) {
+            $mock->shouldReceive('offsetGet')
+                 ->with('config')
+                 ->andReturn(
+                     Mockery::mock(Repository::class, static function (Mockery\MockInterface $mock) {
+                         $mock->shouldReceive('offsetGet')
+                              ->with('auth.providers.fake-provider')
+                              ->andReturn([
+                                  'driver' => 'fake',
+                              ])
+                              ->once();
+                     })
+                 )
+                 ->once();
+        });
+
+        $sprout = new BudAuthManager($app);
+
+        $sprout->provider('fake', function (Application $app, array $config) {
+            $this->assertArrayHasKey('provider', $config);
+            $this->assertSame('fake-provider', $config['provider']);
+
+            return Mockery::mock(UserProvider::class);
+        });
+
+        $sprout->createUserProvider('fake-provider');
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenTheresNoDriverInTheConfig(): void
+    {
+        $app = Mockery::mock(Application::class, static function (Mockery\MockInterface $mock) {
+            $mock->shouldReceive('offsetGet')
+                 ->with('config')
+                 ->andReturn(
+                     Mockery::mock(Repository::class, static function (Mockery\MockInterface $mock) {
+                         $mock->shouldReceive('offsetGet')
+                              ->with('auth.providers.fake-provider')
+                              ->andReturn([
+                                  'name' => 'hi',
+                              ])
+                              ->once();
+                     })
+                 )
+                 ->once();
+        });
+
+        $sprout = new BudAuthManager($app);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Authentication user provider driver must be provided.');
+
+        $sprout->createUserProvider('fake-provider');
+    }
+
+    #[Test]
+    public function returnsNullWhenTheresNoConfig(): void
+    {
+        $app = Mockery::mock(Application::class, static function (Mockery\MockInterface $mock) {
+            $mock->shouldReceive('offsetGet')
+                 ->with('config')
+                 ->andReturn(
+                     Mockery::mock(Repository::class, static function (Mockery\MockInterface $mock) {
+                         $mock->shouldReceive('offsetGet')
+                              ->with('auth.providers.fake-provider')
+                              ->andReturn(null)
+                              ->once();
+                     })
+                 )
+                 ->once();
+        });
+
+        $sprout = new BudAuthManager($app);
+
+        $this->assertNull($sprout->createUserProvider('fake-provider'));
+    }
+
+    #[Test]
+    public function canCreateProvidersNormally(): void
+    {
+        $app = Mockery::mock($this->app, static function (Mockery\MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $sprout = new BudAuthManager($app);
+
+        $this->assertInstanceOf(EloquentUserProvider::class, $sprout->createUserProvider('users'));
+    }
+
+    #[Test]
+    public function throwsAnExceptionForDriversThatDoNotExist(): void
+    {
+        $app = Mockery::mock($this->app, static function (Mockery\MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app['config']['auth.providers.fake.driver'] = 'fake';
+
+        $sprout = new BudAuthManager($app);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Authentication user provider [fake] is not defined.');
+
+        $sprout->createUserProvider('fake');
+    }
+}

--- a/tests/Unit/Overrides/AuthOverrideTest.php
+++ b/tests/Unit/Overrides/AuthOverrideTest.php
@@ -1,0 +1,547 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Tests\Unit\Overrides;
+
+use Closure;
+use Illuminate\Auth\AuthManager;
+use Illuminate\Broadcasting\BroadcastManager;
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Foundation\Application;
+use LogicException;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Contracts\ConfigStore;
+use Sprout\Bud\Exceptions\CyclicOverrideException;
+use Sprout\Bud\Managers\ConfigStoreManager;
+use Sprout\Bud\Overrides\Auth\BudAuthManager;
+use Sprout\Bud\Overrides\AuthManagerOverride;
+use Sprout\Bud\Overrides\AuthProviderOverride;
+use Sprout\Bud\Tests\Unit\UnitTestCase;
+use Sprout\Contracts\BootableServiceOverride;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Contracts\TenantHasResources;
+use Sprout\Overrides\StackedOverride;
+use Sprout\Sprout;
+use Sprout\Support\SettingsRepository;
+use function Sprout\sprout;
+
+class AuthOverrideTest extends UnitTestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], static function (Repository $config) {
+            $config->set('sprout.overrides', []);
+        });
+    }
+
+    private function mockBudAuthManager(bool $extends = true, ?Closure $callback = null): BudAuthManager&MockInterface
+    {
+        return Mockery::mock(BudAuthManager::class, static function (MockInterface $mock) use ($extends, $callback) {
+            if ($extends) {
+                $mock->shouldReceive('provider')
+                     ->with('bud', Mockery::on(static function ($arg) {
+                         return is_callable($arg) && $arg instanceof Closure;
+                     }))
+                     ->once();
+            }
+
+            if ($callback) {
+                $callback($mock);
+            }
+        });
+    }
+
+    #[Test]
+    public function isBuiltCorrectly(): void
+    {
+        $this->assertTrue(is_subclass_of(AuthManagerOverride::class, BootableServiceOverride::class));
+        $this->assertTrue(is_subclass_of(AuthProviderOverride::class, BootableServiceOverride::class));
+    }
+
+    #[Test]
+    public function isRegisteredWithSproutCorrectly(): void
+    {
+        $sprout = sprout();
+
+        config()->set('sprout.overrides', [
+            'auth' => [
+                'driver'    => StackedOverride::class,
+                'overrides' => [
+                    AuthManagerOverride::class,
+                    AuthProviderOverride::class,
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($sprout->overrides()->hasOverride('auth'));
+
+        $sprout->overrides()->registerOverrides();
+
+        $this->assertTrue($sprout->overrides()->hasOverride('auth'));
+        $this->assertSame(StackedOverride::class, $sprout->overrides()->getOverrideClass('auth'));
+        $this->assertTrue($sprout->overrides()->isOverrideBootable('auth'));
+        $this->assertTrue($sprout->overrides()->hasOverrideBooted('auth'));
+    }
+
+    #[Test, DataProvider('authResolvedDataProvider')]
+    public function bootsCorrectly(bool $return): void
+    {
+        $override = new StackedOverride('auth', [
+            'overrides' => [
+                AuthManagerOverride::class,
+                AuthProviderOverride::class,
+            ],
+        ]);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, function (MockInterface $mock) use ($return) {
+            $mock->makePartial();
+
+            if ($return) {
+                $mock->shouldReceive('forgetInstance')->with('auth')->once();
+            }
+
+            $mock->shouldReceive('singleton')
+                 ->with('auth', Mockery::on(static function ($arg) {
+                     return is_callable($arg) && $arg instanceof Closure;
+                 }))
+                 ->once();
+
+            $mock->shouldReceive('resolved')
+                 ->withArgs(['auth'])
+                 ->andReturn($return)
+                 ->times(2);
+
+            if ($return) {
+                $mock->shouldReceive('make')
+                     ->with('auth')
+                     ->andReturn($this->mockBudAuthManager())
+                     ->times(2);
+            } else {
+                $mock->shouldReceive('afterResolving')
+                     ->withArgs([
+                         'auth',
+                         Mockery::on(static function ($arg) {
+                             return is_callable($arg) && $arg instanceof Closure;
+                         }),
+                     ])
+                     ->once();
+            }
+        });
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        // These are only here because there would be errors if their
+        // corresponding setters were not called
+        $this->assertInstanceOf(Application::class, $override->getApp());
+        $this->assertInstanceOf(Sprout::class, $override->getSprout());
+    }
+
+    #[Test]
+    public function errorsWithoutManager(): void
+    {
+        $override = new StackedOverride('auth', [
+            'overrides' => [
+                AuthProviderOverride::class,
+            ],
+        ]);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        // We have to bind the mock so that the extension can be registered.
+        $app->singleton(AuthManager::class, fn () => Mockery::mock(AuthManager::class));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot override auth providers without the Bud auth manager override');
+
+        // This is important, otherwise it doesn't behave nicely with the
+        // afterResolving method.
+        $app->make('auth');
+
+        $override->boot($app, $sprout);
+    }
+
+    #[Test]
+    public function errorsWithNoTenantSpecificConfig(): void
+    {
+        $override = new StackedOverride('auth', [
+            'overrides' => [
+                AuthManagerOverride::class,
+                AuthProviderOverride::class,
+            ],
+        ]);
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+            $mock->shouldReceive('getTenantIdentifier')->andReturn('my-tenant')->once();
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+            $mock->shouldReceive('getName')->andReturn('my-tenancy')->once();
+        });
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'auth',
+                              'bud-provider',
+                          )->andReturn(null);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        /** @var \Sprout\Bud\Overrides\Auth\BudAuthManager $manager */
+        $manager = $app->make('auth');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to find configuration for [auth.bud-provider] for tenant [my-tenant] on tenancy [my-tenancy]');
+
+        $manager->createUserProviderFromConfig(['driver' => 'bud', 'provider' => 'bud-provider']);
+    }
+
+    #[Test]
+    public function errorsIfOverriddenConnectionAlsoUsesBud(): void
+    {
+        $override = new StackedOverride('auth', [
+            'overrides' => [
+                AuthManagerOverride::class,
+                AuthProviderOverride::class,
+            ],
+        ]);
+
+        $tenant  = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'auth',
+                              'bud-provider',
+                          )->andReturn([
+                             'driver' => 'bud',
+                         ]);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        /** @var \Sprout\Bud\Overrides\Auth\BudAuthManager $manager */
+        $manager = $app->make('auth');
+
+        $this->expectException(CyclicOverrideException::class);
+        $this->expectExceptionMessage('Attempt to create cyclic bud auth provider [bud-provider] detected');
+
+        $manager->createUserProviderFromConfig([
+            'driver'   => 'bud',
+            'provider' => 'bud-provider',
+        ]);
+    }
+
+    #[Test]
+    public function keepsTrackOfResolvedBudProviders(): void
+    {
+        $override = new StackedOverride('auth', [
+            'overrides' => [
+                AuthManagerOverride::class,
+                AuthProviderOverride::class,
+            ],
+        ]);
+
+        $tenant  = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'auth',
+                              'bud-provider',
+                          )->andReturn([
+                             'driver' => 'database',
+                             'table'  => 'fake-table',
+                         ]);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        /** @var \Sprout\Bud\Overrides\Auth\BudAuthManager $manager */
+        $manager = $app->make('auth');
+
+        $manager->createUserProviderFromConfig(['provider' => 'bud-provider', 'driver' => 'bud']);
+
+        $this->assertNotEmpty($override->getOverrides()[AuthProviderOverride::class]->getOverrides());
+        $this->assertContains('bud-provider', $override->getOverrides()[AuthProviderOverride::class]->getOverrides());
+    }
+
+    #[Test]
+    public function cleansUpResolvedDrivers(): void
+    {
+        $override = new StackedOverride('auth', [
+            'overrides' => [
+                AuthManagerOverride::class,
+                AuthProviderOverride::class,
+            ],
+        ]);
+
+        $this->app->forgetInstance(BroadcastManager::class);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'auth',
+                              'bud-provider',
+                          )->andReturn([
+                             'driver' => 'database',
+                             'table'  => 'fake-table',
+                         ]);
+                 }));
+        })));
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        $authOverride = $override->getOverride(AuthProviderOverride::class);
+
+        $this->assertEmpty($authOverride->getOverrides());
+
+        /** @var \Sprout\Bud\Overrides\Auth\BudAuthManager $manager */
+        $manager = $app->make('auth');
+
+        $manager->createUserProviderFromConfig(['provider' => 'bud-provider', 'driver' => 'bud']);
+
+        $this->assertNotEmpty($authOverride->getOverrides());
+        $this->assertContains('bud-provider', $authOverride->getOverrides());
+
+        $override->cleanup($tenancy, $tenant);
+
+        $this->assertEmpty($authOverride->getOverrides());
+    }
+
+    #[Test]
+    public function cleansUpResolvedDriversFromPreconfiguredConnections(): void
+    {
+        $override = new StackedOverride('auth', [
+            'overrides' => [
+                AuthManagerOverride::class,
+                AuthProviderOverride::class,
+            ],
+        ]);
+
+        $this->app->forgetInstance('auth');
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+
+        $app->make('config')->set('auth.providers.bud-provider', [
+            'driver' => 'bud',
+        ]);
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'auth',
+                              'bud-provider',
+                          )->andReturn([
+                             'driver' => 'database',
+                             'table'  => 'fake-table',
+                         ]);
+                 }));
+        })));
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        $authOverride = $override->getOverride(AuthProviderOverride::class);
+
+        $this->assertEmpty($authOverride->getOverrides());
+
+        /** @var \Sprout\Bud\Overrides\Auth\BudAuthManager $manager */
+        $manager = $app->make('auth');
+
+        $manager->createUserProvider('bud-provider');
+
+        $this->assertNotEmpty($authOverride->getOverrides());
+        $this->assertContains('bud-provider', $authOverride->getOverrides());
+
+        $override->cleanup($tenancy, $tenant);
+
+        $this->assertEmpty($authOverride->getOverrides());
+    }
+
+    #[Test]
+    public function cleansUpNothingWithoutResolvedDrivers(): void
+    {
+        $override = new StackedOverride('auth', [
+            'overrides' => [
+                AuthManagerOverride::class,
+                AuthProviderOverride::class,
+            ],
+        ]);
+
+        $this->app->forgetInstance('auth');
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+
+        $app->make('config')->set('authing.connections.bud-provider', [
+            'driver' => 'bud',
+        ]);
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+        });
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        $authOverride = $override->getOverride(AuthProviderOverride::class);
+
+        $this->assertEmpty($authOverride->getOverrides());
+
+        $override->cleanup($tenancy, $tenant);
+
+        $this->assertEmpty($authOverride->getOverrides());
+    }
+
+    public static function authResolvedDataProvider(): array
+    {
+        return [
+            'auth resolved'     => [true],
+            'auth not resolved' => [false],
+        ];
+    }
+}

--- a/tests/Unit/Overrides/AuthOverrideTest.php
+++ b/tests/Unit/Overrides/AuthOverrideTest.php
@@ -5,7 +5,6 @@ namespace Sprout\Bud\Tests\Unit\Overrides;
 
 use Closure;
 use Illuminate\Auth\AuthManager;
-use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use LogicException;
@@ -361,7 +360,7 @@ class AuthOverrideTest extends UnitTestCase
             ],
         ]);
 
-        $this->app->forgetInstance(BroadcastManager::class);
+        $this->app->forgetInstance('auth');
 
         /** @var \Illuminate\Foundation\Application&MockInterface $app */
         $app = Mockery::mock($this->app, static function (MockInterface $mock) {
@@ -510,7 +509,7 @@ class AuthOverrideTest extends UnitTestCase
 
         $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
 
-        $app->make('config')->set('authing.connections.bud-provider', [
+        $app->make('config')->set('auth.providers.bud-provider', [
             'driver' => 'bud',
         ]);
 

--- a/tests/Unit/Overrides/Broadcast/BudBroadcastConnectionCreatorTest.php
+++ b/tests/Unit/Overrides/Broadcast/BudBroadcastConnectionCreatorTest.php
@@ -1,0 +1,242 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Tests\Unit\Overrides\Broadcast;
+
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Illuminate\Foundation\Application;
+use InvalidArgumentException;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Contracts\ConfigStore;
+use Sprout\Bud\Managers\ConfigStoreManager;
+use Sprout\Bud\Overrides\Broadcast\BudBroadcastConnectionCreator;
+use Sprout\Bud\Overrides\Broadcast\BudBroadcastManager;
+use Sprout\Bud\Tests\Unit\UnitTestCase;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Contracts\TenantHasResources;
+use Sprout\Exceptions\MisconfigurationException;
+use Sprout\Exceptions\TenancyMissingException;
+use Sprout\Exceptions\TenantMissingException;
+use Sprout\Overrides\Filesystem\SproutFilesystemDriverCreator;
+use Sprout\Sprout;
+use Sprout\Support\SettingsRepository;
+
+class BudBroadcastConnectionCreatorTest extends UnitTestCase
+{
+    private function mockApplication(bool $default = false): Application&Mockery\MockInterface
+    {
+        return Mockery::mock(Application::class, static function (Mockery\MockInterface $mock) use ($default) {
+            $mock->shouldIgnoreMissing();
+        });
+    }
+
+    private function mockManager(bool $driver = true): BudBroadcastManager&Mockery\MockInterface
+    {
+        return Mockery::mock(BudBroadcastManager::class, static function (Mockery\MockInterface $mock) use ($driver) {
+            if ($driver) {
+                $mock->shouldReceive('connectUsing')
+                     ->with(
+                         'fake-connection',
+                         ['name' => 'fake-connection', 'driver' => 'null'],
+                         true
+                     )
+                     ->andReturn(Mockery::mock(Broadcaster::class))
+                     ->once();
+            }
+        });
+    }
+
+    private function mockConfigStoreManager(?Tenancy $tenancy = null, ?Tenant $tenant = null): ConfigStoreManager&Mockery\MockInterface
+    {
+        return Mockery::mock(ConfigStoreManager::class, static function (Mockery\MockInterface $mock) use ($tenancy, $tenant) {
+            if ($tenancy && $tenant) {
+                $mock->shouldReceive('get')
+                     ->with(null)
+                     ->andReturn(Mockery::mock(ConfigStore::class, static function (Mockery\MockInterface $mock) use ($tenancy, $tenant) {
+                         $mock->shouldReceive('get')
+                              ->with(
+                                  $tenancy,
+                                  $tenant,
+                                  'broadcast',
+                                  'fake-connection'
+                              )
+                              ->andReturn([
+                                  'driver' => 'null',
+                              ])
+                              ->once();
+                     }))
+                     ->once();
+            }
+        });
+    }
+
+    private function getSprout(Application $app, bool $withTenancy = true, bool $withTenant = true, bool $withResources = true): Sprout
+    {
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        if ($withTenant) {
+            if ($withResources) {
+                $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (Mockery\MockInterface $mock) {
+                });
+            } else {
+                $tenant = Mockery::mock(Tenant::class);
+            }
+
+
+        } else {
+            $tenant = null;
+        }
+
+        if ($withTenancy) {
+            $sprout->setCurrentTenancy(Mockery::mock(Tenancy::class, static function (Mockery\MockInterface $mock) use ($tenant, $withTenant) {
+                $mock->shouldReceive('check')->andReturn($withTenant)->once();
+
+                if ($withTenant) {
+                    $mock->shouldReceive('tenant')->andReturn($tenant)->twice();
+                } else {
+                    $mock->shouldReceive('getName')->andReturn('my-tenancy')->once();
+                }
+            }));
+        }
+
+        return $sprout;
+    }
+
+    private function getBud(Application $app, ConfigStoreManager $manager): Bud
+    {
+        return new Bud($app, $manager);
+    }
+
+    #[Test]
+    public function canCreateTheDriver(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager();
+        $config  = [
+            'name'   => 'fake-connection',
+            'driver' => 'fake-driver',
+        ];
+        $sprout  = $this->getSprout($app);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager($sprout->getCurrentTenancy(), $sprout->getCurrentTenancy()->tenant()));
+
+        $creator = new BudBroadcastConnectionCreator(
+            $manager,
+            $bud,
+            $sprout,
+            $config,
+        );
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenConfigIsMissingName(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [];
+        $sprout  = $this->getSprout($app, false, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $sprout->markAsOutsideContext();
+
+        $this->assertFalse($sprout->withinContext());
+
+        $creator = new BudBroadcastConnectionCreator(
+            $manager,
+            $bud,
+            $sprout,
+            $config
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Broadcast connection name must be provided');
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenOutsideOfContext(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [
+            'name' => 'fake-connection',
+        ];
+        $sprout  = $this->getSprout($app, false, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $sprout->markAsOutsideContext();
+
+        $this->assertFalse($sprout->withinContext());
+
+        $creator = new BudBroadcastConnectionCreator(
+            $manager,
+            $bud,
+            $sprout,
+            $config
+        );
+
+        $this->expectException(TenancyMissingException::class);
+        $this->expectExceptionMessage('There is no current tenancy');
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenThereIsNoTenancy(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [
+            'name' => 'fake-connection',
+        ];
+        $sprout  = $this->getSprout($app, false, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $sprout->markAsInContext();
+
+        $this->assertTrue($sprout->withinContext());
+
+        $creator = new BudBroadcastConnectionCreator(
+            $manager,
+            $bud,
+            $sprout,
+            $config
+        );
+
+        $this->expectException(TenancyMissingException::class);
+        $this->expectExceptionMessage('There is no current tenancy');
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenThereIsNoTenant(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [
+            'name' => 'fake-connection',
+        ];
+        $sprout  = $this->getSprout($app, true, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $this->assertTrue($sprout->withinContext());
+
+        $creator = new BudBroadcastConnectionCreator(
+            $manager,
+            $bud,
+            $sprout,
+            $config
+        );
+
+        $this->expectException(TenantMissingException::class);
+        $this->expectExceptionMessage('There is no current tenant for tenancy [my-tenancy]');
+
+        $creator();
+    }
+}

--- a/tests/Unit/Overrides/Broadcast/BudBroadcastConnectionCreatorTest.php
+++ b/tests/Unit/Overrides/Broadcast/BudBroadcastConnectionCreatorTest.php
@@ -82,8 +82,6 @@ class BudBroadcastConnectionCreatorTest extends UnitTestCase
             } else {
                 $tenant = Mockery::mock(Tenant::class);
             }
-
-
         } else {
             $tenant = null;
         }

--- a/tests/Unit/Overrides/Broadcast/BudBroadcastManagerTest.php
+++ b/tests/Unit/Overrides/Broadcast/BudBroadcastManagerTest.php
@@ -112,7 +112,7 @@ class BudBroadcastManagerTest extends UnitTestCase
     }
 
     #[Test]
-    public function canCreateDisksNormally(): void
+    public function canCreateConnectionsNormally(): void
     {
         $app = Mockery::mock($this->app, static function (Mockery\MockInterface $mock) {
             $mock->makePartial();

--- a/tests/Unit/Overrides/Broadcast/BudBroadcastManagerTest.php
+++ b/tests/Unit/Overrides/Broadcast/BudBroadcastManagerTest.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Tests\Unit\Overrides\Broadcast;
+
+use Illuminate\Broadcasting\Broadcasters\NullBroadcaster;
+use Illuminate\Broadcasting\BroadcastManager;
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Filesystem\LocalFilesystemAdapter;
+use Illuminate\Foundation\Application;
+use InvalidArgumentException;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Bud\Overrides\Broadcast\BudBroadcastManager;
+use Sprout\Bud\Tests\Unit\UnitTestCase;
+use Sprout\Overrides\Filesystem\SproutFilesystemManager;
+
+class BudBroadcastManagerTest extends UnitTestCase
+{
+    #[Test]
+    public function canBySyncedFromOriginal(): void
+    {
+        $original = Mockery::mock(BroadcastManager::class);
+
+        $app = Mockery::mock(Application::class);
+
+        $sprout = new BudBroadcastManager($app, $original);
+
+        $this->assertTrue($sprout->wasSyncedFromOriginal());
+    }
+
+    #[Test]
+    public function addsNameWhenResolvingDriver(): void
+    {
+        $app = Mockery::mock(Application::class, static function (Mockery\MockInterface $mock) {
+            $mock->shouldReceive('offsetGet')
+                 ->with('config')
+                 ->andReturn(
+                     Mockery::mock(Repository::class, static function (Mockery\MockInterface $mock) {
+                         $mock->shouldReceive('offsetGet')
+                              ->with('broadcasting.connections.fake-connection')
+                              ->andReturn([
+                                  'driver' => 'fake',
+                              ])
+                              ->once();
+                     })
+                 )
+                 ->once();
+        });
+
+        $sprout = new BudBroadcastManager($app);
+
+        $sprout->extend('fake', function (Application $app, array $config) {
+            $this->assertArrayHasKey('name', $config);
+            $this->assertSame('fake-connection', $config['name']);
+
+            return Mockery::mock(Broadcaster::class);
+        });
+
+        $sprout->connection('fake-connection');
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenTheresNoDriverInTheConfig(): void
+    {
+        $app = Mockery::mock(Application::class, static function (Mockery\MockInterface $mock) {
+            $mock->shouldReceive('offsetGet')
+                 ->with('config')
+                 ->andReturn(
+                     Mockery::mock(Repository::class, static function (Mockery\MockInterface $mock) {
+                         $mock->shouldReceive('offsetGet')
+                              ->with('broadcasting.connections.fake-connection')
+                              ->andReturn([
+                                  'name' => 'hi',
+                              ])
+                              ->once();
+                     })
+                 )
+                 ->once();
+        });
+
+        $sprout = new BudBroadcastManager($app);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Broadcast connection [fake-connection] does not have a configured driver.');
+
+        $sprout->connection('fake-connection');
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenTheresNoConfig(): void
+    {
+        $app = Mockery::mock(Application::class, static function (Mockery\MockInterface $mock) {
+            $mock->shouldReceive('offsetGet')
+                 ->with('config')
+                 ->andReturn(
+                     Mockery::mock(Repository::class, static function (Mockery\MockInterface $mock) {
+                         $mock->shouldReceive('offsetGet')
+                              ->with('broadcasting.connections.fake-connection')
+                              ->andReturn(null)
+                              ->once();
+                     })
+                 )
+                 ->once();
+        });
+
+        $sprout = new BudBroadcastManager($app);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Broadcast connection [fake-connection] is not defined.');
+
+        $sprout->connection('fake-connection');
+    }
+
+    #[Test]
+    public function canCreateDisksNormally(): void
+    {
+        $app = Mockery::mock($this->app, static function (Mockery\MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $sprout = new BudBroadcastManager($app);
+
+        $this->assertInstanceOf(NullBroadcaster::class, $sprout->connection('null'));
+    }
+
+    #[Test]
+    public function throwsAnExceptionForDriversThatDoNotExist(): void
+    {
+        $app = Mockery::mock($this->app, static function (Mockery\MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app['config']['broadcasting.connections.fake.driver'] = 'fake';
+
+        $sprout = new BudBroadcastManager($app);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Driver [fake] is not supported.');
+
+        $sprout->connection('fake');
+    }
+}

--- a/tests/Unit/Overrides/Broadcast/BudBroadcastManagerTest.php
+++ b/tests/Unit/Overrides/Broadcast/BudBroadcastManagerTest.php
@@ -7,20 +7,17 @@ use Illuminate\Broadcasting\Broadcasters\NullBroadcaster;
 use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Broadcasting\Broadcaster;
-use Illuminate\Contracts\Filesystem\Filesystem;
-use Illuminate\Filesystem\LocalFilesystemAdapter;
 use Illuminate\Foundation\Application;
 use InvalidArgumentException;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Sprout\Bud\Overrides\Broadcast\BudBroadcastManager;
 use Sprout\Bud\Tests\Unit\UnitTestCase;
-use Sprout\Overrides\Filesystem\SproutFilesystemManager;
 
 class BudBroadcastManagerTest extends UnitTestCase
 {
     #[Test]
-    public function canBySyncedFromOriginal(): void
+    public function canBeSyncedFromOriginal(): void
     {
         $original = Mockery::mock(BroadcastManager::class);
 

--- a/tests/Unit/Overrides/BroadcastOverrideTest.php
+++ b/tests/Unit/Overrides/BroadcastOverrideTest.php
@@ -531,8 +531,6 @@ class BroadcastOverrideTest extends UnitTestCase
 
         $this->assertEmpty($broadcastOverride->getOverrides());
 
-        $this->assertEmpty($broadcastOverride->getOverrides());
-
         $override->cleanup($tenancy, $tenant);
 
         $this->assertEmpty($broadcastOverride->getOverrides());

--- a/tests/Unit/Overrides/BroadcastOverrideTest.php
+++ b/tests/Unit/Overrides/BroadcastOverrideTest.php
@@ -355,7 +355,7 @@ class BroadcastOverrideTest extends UnitTestCase
     #[Test]
     public function cleansUpResolvedDrivers(): void
     {
-        $override = new StackedOverride('filesystem', [
+        $override = new StackedOverride('broadcast', [
             'overrides' => [
                 BroadcastManagerOverride::class,
                 BroadcastConnectionOverride::class,
@@ -423,7 +423,7 @@ class BroadcastOverrideTest extends UnitTestCase
     #[Test]
     public function cleansUpResolvedDriversFromPreconfiguredConnections(): void
     {
-        $override = new StackedOverride('filesystem', [
+        $override = new StackedOverride('broadcast', [
             'overrides' => [
                 BroadcastManagerOverride::class,
                 BroadcastConnectionOverride::class,
@@ -493,7 +493,7 @@ class BroadcastOverrideTest extends UnitTestCase
     #[Test]
     public function cleansUpNothingWithoutResolvedDrivers(): void
     {
-        $override = new StackedOverride('filesystem', [
+        $override = new StackedOverride('broadcast', [
             'overrides' => [
                 BroadcastManagerOverride::class,
                 BroadcastConnectionOverride::class,

--- a/tests/Unit/Overrides/BroadcastOverrideTest.php
+++ b/tests/Unit/Overrides/BroadcastOverrideTest.php
@@ -1,0 +1,550 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Tests\Unit\Overrides;
+
+use Closure;
+use Illuminate\Broadcasting\BroadcastManager;
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Foundation\Application;
+use LogicException;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Contracts\ConfigStore;
+use Sprout\Bud\Exceptions\CyclicOverrideException;
+use Sprout\Bud\Managers\ConfigStoreManager;
+use Sprout\Bud\Overrides\Broadcast\BudBroadcastManager;
+use Sprout\Bud\Overrides\BroadcastConnectionOverride;
+use Sprout\Bud\Overrides\BroadcastManagerOverride;
+use Sprout\Bud\Tests\Unit\UnitTestCase;
+use Sprout\Contracts\BootableServiceOverride;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Contracts\TenantHasResources;
+use Sprout\Overrides\StackedOverride;
+use Sprout\Sprout;
+use Sprout\Support\SettingsRepository;
+use function Sprout\sprout;
+
+class BroadcastOverrideTest extends UnitTestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], static function (Repository $config) {
+            $config->set('sprout.overrides', []);
+        });
+    }
+
+    private function mockBudBroadcastManager(bool $extends = true, ?Closure $callback = null): BudBroadcastManager&MockInterface
+    {
+        return Mockery::mock(BudBroadcastManager::class, static function (MockInterface $mock) use ($extends, $callback) {
+            if ($extends) {
+                $mock->shouldReceive('extend')
+                     ->with('bud', Mockery::on(static function ($arg) {
+                         return is_callable($arg) && $arg instanceof Closure;
+                     }))
+                     ->once();
+            }
+
+            if ($callback) {
+                $callback($mock);
+            }
+        });
+    }
+
+    #[Test]
+    public function isBuiltCorrectly(): void
+    {
+        $this->assertTrue(is_subclass_of(BroadcastManagerOverride::class, BootableServiceOverride::class));
+        $this->assertTrue(is_subclass_of(BroadcastConnectionOverride::class, BootableServiceOverride::class));
+    }
+
+    #[Test]
+    public function isRegisteredWithSproutCorrectly(): void
+    {
+        $sprout = sprout();
+
+        config()->set('sprout.overrides', [
+            'broadcast' => [
+                'driver'    => StackedOverride::class,
+                'overrides' => [
+                    BroadcastManagerOverride::class,
+                    BroadcastConnectionOverride::class,
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($sprout->overrides()->hasOverride('broadcast'));
+
+        $sprout->overrides()->registerOverrides();
+
+        $this->assertTrue($sprout->overrides()->hasOverride('broadcast'));
+        $this->assertSame(StackedOverride::class, $sprout->overrides()->getOverrideClass('broadcast'));
+        $this->assertTrue($sprout->overrides()->isOverrideBootable('broadcast'));
+        $this->assertTrue($sprout->overrides()->hasOverrideBooted('broadcast'));
+    }
+
+    #[Test, DataProvider('broadcastResolvedDataProvider')]
+    public function bootsCorrectly(bool $return): void
+    {
+        $override = new StackedOverride('broadcast', [
+            'overrides' => [
+                BroadcastManagerOverride::class,
+                BroadcastConnectionOverride::class,
+            ],
+        ]);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, function (MockInterface $mock) use ($return) {
+            $mock->makePartial();
+
+            if ($return) {
+                $mock->shouldReceive('forgetInstance')->with(BroadcastManager::class)->once();
+            }
+
+            $mock->shouldReceive('singleton')
+                 ->with(BroadcastManager::class, Mockery::on(static function ($arg) {
+                     return is_callable($arg) && $arg instanceof Closure;
+                 }))
+                 ->once();
+
+            $mock->shouldReceive('resolved')
+                 ->withArgs([BroadcastManager::class])
+                 ->andReturn($return)
+                 ->times(2);
+
+            if ($return) {
+                $mock->shouldReceive('make')
+                     ->with(BroadcastManager::class)
+                     ->andReturn($this->mockBudBroadcastManager())
+                     ->times(2);
+            } else {
+                $mock->shouldReceive('afterResolving')
+                     ->withArgs([
+                         BroadcastManager::class,
+                         Mockery::on(static function ($arg) {
+                             return is_callable($arg) && $arg instanceof Closure;
+                         }),
+                     ])
+                     ->once();
+            }
+        });
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        // These are only here because there would be errors if their
+        // corresponding setters were not called
+        $this->assertInstanceOf(Application::class, $override->getApp());
+        $this->assertInstanceOf(Sprout::class, $override->getSprout());
+    }
+
+    #[Test]
+    public function errorsWithoutManager(): void
+    {
+        $override = new StackedOverride('broadcast', [
+            'overrides' => [
+                BroadcastConnectionOverride::class,
+            ],
+        ]);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        // We have to bind the mock so that the extension can be registered.
+        $app->singleton(BroadcastManager::class, fn () => Mockery::mock(BroadcastManager::class));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot override broadcast connections without the Bud broadcast manager override');
+
+        // This is important, otherwise it doesn't behave nicely with the
+        // afterResolving method.
+        $app->make(BroadcastManager::class);
+
+        $override->boot($app, $sprout);
+    }
+
+    #[Test]
+    public function errorsWithNoTenantSpecificConfig(): void
+    {
+        $override = new StackedOverride('broadcast', [
+            'overrides' => [
+                BroadcastManagerOverride::class,
+                BroadcastConnectionOverride::class,
+            ],
+        ]);
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+            $mock->shouldReceive('getTenantIdentifier')->andReturn('my-tenant')->once();
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+            $mock->shouldReceive('getName')->andReturn('my-tenancy')->once();
+        });
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'broadcast',
+                              'bud-connection',
+                          )->andReturn(null);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        /** @var \Sprout\Bud\Overrides\Broadcast\BudBroadcastManager $manager */
+        $manager = $app->make(BroadcastManager::class);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to find configuration for [broadcast.bud-connection] for tenant [my-tenant] on tenancy [my-tenancy]');
+
+        $manager->connectUsing('bud-connection', [
+            'driver' => 'bud',
+        ]);
+    }
+
+    #[Test]
+    public function errorsIfOverriddenConnectionAlsoUsesBud(): void
+    {
+        $override = new StackedOverride('broadcast', [
+            'overrides' => [
+                BroadcastManagerOverride::class,
+                BroadcastConnectionOverride::class,
+            ],
+        ]);
+
+        $tenant  = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'broadcast',
+                              'bud-connection',
+                          )->andReturn([
+                             'driver' => 'bud',
+                         ]);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        /** @var \Sprout\Bud\Overrides\Broadcast\BudBroadcastManager $manager */
+        $manager = $app->make(BroadcastManager::class);
+
+        $this->expectException(CyclicOverrideException::class);
+        $this->expectExceptionMessage('Attempt to create cyclic bud broadcast connection [bud-connection] detected');
+
+        $manager->connectUsing('bud-connection', [
+            'driver' => 'bud',
+        ]);
+    }
+
+    #[Test]
+    public function keepsTrackOfResolvedBudDrivers(): void
+    {
+        $override = new StackedOverride('broadcast', [
+            'overrides' => [
+                BroadcastManagerOverride::class,
+                BroadcastConnectionOverride::class,
+            ],
+        ]);
+
+        $tenant  = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'broadcast',
+                              'bud-connection',
+                          )->andReturn([
+                             'driver' => 'null',
+                         ]);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        /** @var \Sprout\Bud\Overrides\Broadcast\BudBroadcastManager $manager */
+        $manager = $app->make(BroadcastManager::class);
+
+        $manager->connectUsing('bud-connection', [
+            'driver' => 'bud',
+        ]);
+
+        $this->assertNotEmpty($override->getOverrides()[BroadcastConnectionOverride::class]->getOverrides());
+        $this->assertContains('bud-connection', $override->getOverrides()[BroadcastConnectionOverride::class]->getOverrides());
+    }
+
+    #[Test]
+    public function cleansUpResolvedDrivers(): void
+    {
+        $override = new StackedOverride('filesystem', [
+            'overrides' => [
+                BroadcastManagerOverride::class,
+                BroadcastConnectionOverride::class,
+            ],
+        ]);
+
+        $this->app->forgetInstance(BroadcastManager::class);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'broadcast',
+                              'bud-connection',
+                          )->andReturn([
+                             'driver' => 'null',
+                         ]);
+                 }));
+        })));
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        $broadcastOverride = $override->getOverride(BroadcastConnectionOverride::class);
+
+        $this->assertEmpty($broadcastOverride->getOverrides());
+
+        $manager = $app->make(BroadcastManager::class);
+
+        $manager->connectUsing('bud-connection', [
+            'driver' => 'bud',
+        ]);
+
+        $this->assertNotEmpty($broadcastOverride->getOverrides());
+        $this->assertContains('bud-connection', $broadcastOverride->getOverrides());
+
+        $override->cleanup($tenancy, $tenant);
+
+        $this->assertEmpty($broadcastOverride->getOverrides());
+    }
+
+    #[Test]
+    public function cleansUpResolvedDriversFromPreconfiguredConnections(): void
+    {
+        $override = new StackedOverride('filesystem', [
+            'overrides' => [
+                BroadcastManagerOverride::class,
+                BroadcastConnectionOverride::class,
+            ],
+        ]);
+
+        $this->app->forgetInstance(BroadcastManager::class);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+
+        $app->make('config')->set('broadcasting.connections.bud-connection', [
+            'driver' => 'bud',
+        ]);
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'broadcast',
+                              'bud-connection',
+                          )->andReturn([
+                             'driver' => 'null',
+                         ]);
+                 }));
+        })));
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        $broadcastOverride = $override->getOverride(BroadcastConnectionOverride::class);
+
+        $this->assertEmpty($broadcastOverride->getOverrides());
+
+        $manager = $app->make(BroadcastManager::class);
+
+        $manager->connection('bud-connection');
+
+        $this->assertNotEmpty($broadcastOverride->getOverrides());
+        $this->assertContains('bud-connection', $broadcastOverride->getOverrides());
+
+        $override->cleanup($tenancy, $tenant);
+
+        $this->assertEmpty($broadcastOverride->getOverrides());
+    }
+
+    #[Test]
+    public function cleansUpNothingWithoutResolvedDrivers(): void
+    {
+        $override = new StackedOverride('filesystem', [
+            'overrides' => [
+                BroadcastManagerOverride::class,
+                BroadcastConnectionOverride::class,
+            ],
+        ]);
+
+        $this->app->forgetInstance(BroadcastManager::class);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+
+        $app->make('config')->set('broadcasting.connections.bud-connection', [
+            'driver' => 'bud',
+        ]);
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+        });
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        $broadcastOverride = $override->getOverride(BroadcastConnectionOverride::class);
+
+        $this->assertEmpty($broadcastOverride->getOverrides());
+
+        $this->assertEmpty($broadcastOverride->getOverrides());
+
+        $override->cleanup($tenancy, $tenant);
+
+        $this->assertEmpty($broadcastOverride->getOverrides());
+    }
+
+    public static function broadcastResolvedDataProvider(): array
+    {
+        return [
+            'cache resolved no manager override'     => [true],
+            'cache not resolved no manager override' => [false],
+            'cache resolved manager override'        => [true],
+            'cache not resolved  manager override'   => [false],
+        ];
+    }
+}

--- a/tests/Unit/Overrides/Cache/BudCacheStoreCreatorTest.php
+++ b/tests/Unit/Overrides/Cache/BudCacheStoreCreatorTest.php
@@ -1,0 +1,215 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Tests\Unit\Overrides\Cache;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Foundation\Application;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Contracts\ConfigStore;
+use Sprout\Bud\Managers\ConfigStoreManager;
+use Sprout\Bud\Overrides\Cache\BudCacheStoreCreator;
+use Sprout\Bud\Tests\Unit\UnitTestCase;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Contracts\TenantHasResources;
+use Sprout\Exceptions\TenancyMissingException;
+use Sprout\Exceptions\TenantMissingException;
+use Sprout\Sprout;
+use Sprout\Support\SettingsRepository;
+
+class BudCacheStoreCreatorTest extends UnitTestCase
+{
+    private function mockApplication(bool $default = false): Application&Mockery\MockInterface
+    {
+        return Mockery::mock(Application::class, static function (Mockery\MockInterface $mock) use ($default) {
+            $mock->shouldIgnoreMissing();
+        });
+    }
+
+    private function mockManager(bool $driver = true): CacheManager&Mockery\MockInterface
+    {
+        return Mockery::mock(CacheManager::class, static function (Mockery\MockInterface $mock) use ($driver) {
+            if ($driver) {
+                $mock->shouldReceive('build')
+                     ->with(
+                         ['driver' => 'array'],
+                     )
+                     ->andReturn(Mockery::mock(Repository::class))
+                     ->once();
+            }
+        });
+    }
+
+    private function mockConfigStoreManager(?Tenancy $tenancy = null, ?Tenant $tenant = null): ConfigStoreManager&Mockery\MockInterface
+    {
+        return Mockery::mock(ConfigStoreManager::class, static function (Mockery\MockInterface $mock) use ($tenancy, $tenant) {
+            if ($tenancy && $tenant) {
+                $mock->shouldReceive('get')
+                     ->with(null)
+                     ->andReturn(Mockery::mock(ConfigStore::class, static function (Mockery\MockInterface $mock) use ($tenancy, $tenant) {
+                         $mock->shouldReceive('get')
+                              ->with(
+                                  $tenancy,
+                                  $tenant,
+                                  'cache',
+                                  'fake-cache'
+                              )
+                              ->andReturn([
+                                  'driver' => 'array',
+                              ])
+                              ->once();
+                     }))
+                     ->once();
+            }
+        });
+    }
+
+    private function getSprout(Application $app, bool $withTenancy = true, bool $withTenant = true, bool $withResources = true): Sprout
+    {
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        if ($withTenant) {
+            if ($withResources) {
+                $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (Mockery\MockInterface $mock) {
+                });
+            } else {
+                $tenant = Mockery::mock(Tenant::class);
+            }
+
+
+        } else {
+            $tenant = null;
+        }
+
+        if ($withTenancy) {
+            $sprout->setCurrentTenancy(Mockery::mock(Tenancy::class, static function (Mockery\MockInterface $mock) use ($tenant, $withTenant) {
+                $mock->shouldReceive('check')->andReturn($withTenant)->once();
+
+                if ($withTenant) {
+                    $mock->shouldReceive('tenant')->andReturn($tenant)->twice();
+                } else {
+                    $mock->shouldReceive('getName')->andReturn('my-tenancy')->once();
+                }
+            }));
+        }
+
+        return $sprout;
+    }
+
+    private function getBud(Application $app, ConfigStoreManager $manager): Bud
+    {
+        return new Bud($app, $manager);
+    }
+
+    #[Test]
+    public function canCreateTheDriver(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager();
+        $config  = [
+            'store'  => 'fake-cache',
+            'driver' => 'fake-cache',
+        ];
+        $sprout  = $this->getSprout($app);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager($sprout->getCurrentTenancy(), $sprout->getCurrentTenancy()->tenant()));
+
+        $creator = new BudCacheStoreCreator(
+            $manager,
+            $bud,
+            $sprout,
+            'fake-cache',
+            $config,
+        );
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenOutsideOfContext(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [
+            'store' => 'fake-cache',
+        ];
+        $sprout  = $this->getSprout($app, false, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $sprout->markAsOutsideContext();
+
+        $this->assertFalse($sprout->withinContext());
+
+        $creator = new BudCacheStoreCreator(
+            $manager,
+            $bud,
+            $sprout,
+            'fake-cache',
+            $config,
+        );
+
+        $this->expectException(TenancyMissingException::class);
+        $this->expectExceptionMessage('There is no current tenancy');
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenThereIsNoTenancy(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [
+            'store' => 'fake-cache',
+        ];
+        $sprout  = $this->getSprout($app, false, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $sprout->markAsInContext();
+
+        $this->assertTrue($sprout->withinContext());
+
+        $creator = new BudCacheStoreCreator(
+            $manager,
+            $bud,
+            $sprout,
+            'fake-cache',
+            $config,
+        );
+
+        $this->expectException(TenancyMissingException::class);
+        $this->expectExceptionMessage('There is no current tenancy');
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenThereIsNoTenant(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [
+            'store' => 'fake-cache',
+        ];
+        $sprout  = $this->getSprout($app, true, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $this->assertTrue($sprout->withinContext());
+
+        $creator = new BudCacheStoreCreator(
+            $manager,
+            $bud,
+            $sprout,
+            'fake-cache',
+            $config,
+        );
+
+        $this->expectException(TenantMissingException::class);
+        $this->expectExceptionMessage('There is no current tenant for tenancy [my-tenancy]');
+
+        $creator();
+    }
+}

--- a/tests/Unit/Overrides/Cache/BudCacheStoreCreatorTest.php
+++ b/tests/Unit/Overrides/Cache/BudCacheStoreCreatorTest.php
@@ -79,8 +79,6 @@ class BudCacheStoreCreatorTest extends UnitTestCase
             } else {
                 $tenant = Mockery::mock(Tenant::class);
             }
-
-
         } else {
             $tenant = null;
         }

--- a/tests/Unit/Overrides/CacheStoreOverrideTest.php
+++ b/tests/Unit/Overrides/CacheStoreOverrideTest.php
@@ -271,7 +271,7 @@ class CacheStoreOverrideTest extends UnitTestCase
 
         $this->assertEmpty($override->getOverrides());
 
-        /** @var \Illuminate\Mail\MailManager $manager */
+        /** @var \Illuminate\Cache\CacheManager $manager */
         $manager = $app->make('cache');
 
         $manager->store('bud-cache');

--- a/tests/Unit/Overrides/CacheStoreOverrideTest.php
+++ b/tests/Unit/Overrides/CacheStoreOverrideTest.php
@@ -168,7 +168,7 @@ class CacheStoreOverrideTest extends UnitTestCase
     #[Test]
     public function keepsTrackOfResolvedBudDrivers(): void
     {
-        $override = new CacheStoreOverride('mailer', []);
+        $override = new CacheStoreOverride('cache', []);
 
         /** @var \Illuminate\Foundation\Application&MockInterface $app */
         $app = Mockery::mock($this->app, static function (MockInterface $mock) {
@@ -223,7 +223,7 @@ class CacheStoreOverrideTest extends UnitTestCase
     #[Test]
     public function cleansUpResolvedDrivers(): void
     {
-        $override = new CacheStoreOverride('mailer', []);
+        $override = new CacheStoreOverride('cache', []);
 
         $this->app->forgetInstance('cache');
 
@@ -287,7 +287,7 @@ class CacheStoreOverrideTest extends UnitTestCase
     #[Test]
     public function cleansUpNothingWithoutResolvedDrivers(): void
     {
-        $override = new CacheStoreOverride('mailer', []);
+        $override = new CacheStoreOverride('cache', []);
 
         $this->app->forgetInstance('cache');
 

--- a/tests/Unit/Overrides/CacheStoreOverrideTest.php
+++ b/tests/Unit/Overrides/CacheStoreOverrideTest.php
@@ -1,0 +1,332 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Tests\Unit\Overrides;
+
+use Closure;
+use Illuminate\Cache\CacheManager;
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Foundation\Application;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Contracts\ConfigStore;
+use Sprout\Bud\Exceptions\CyclicOverrideException;
+use Sprout\Bud\Managers\ConfigStoreManager;
+use Sprout\Bud\Overrides\CacheStoreOverride;
+use Sprout\Bud\Tests\Unit\UnitTestCase;
+use Sprout\Contracts\BootableServiceOverride;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Contracts\TenantHasResources;
+use Sprout\Sprout;
+use Sprout\Support\SettingsRepository;
+use function Sprout\sprout;
+
+class CacheStoreOverrideTest extends UnitTestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], static function (Repository $config) {
+            $config->set('sprout.overrides', []);
+        });
+    }
+
+    private function mockCacheManager(): CacheManager&MockInterface
+    {
+        return Mockery::mock(CacheManager::class, static function (MockInterface $mock) {
+            $mock->shouldReceive('extend')
+                 ->with('bud', Mockery::on(static function ($arg) {
+                     return is_callable($arg) && $arg instanceof Closure;
+                 }))
+                 ->once();
+        });
+    }
+
+    #[Test]
+    public function isBuiltCorrectly(): void
+    {
+        $this->assertTrue(is_subclass_of(CacheStoreOverride::class, BootableServiceOverride::class));
+    }
+
+    #[Test]
+    public function isRegisteredWithSproutCorrectly(): void
+    {
+        $sprout = sprout();
+
+        config()->set('sprout.overrides', [
+            'cache' => [
+                'driver' => CacheStoreOverride::class,
+            ],
+        ]);
+
+        $this->assertFalse($sprout->overrides()->hasOverride('cache'));
+
+        $sprout->overrides()->registerOverrides();
+
+        $this->assertTrue($sprout->overrides()->hasOverride('cache'));
+        $this->assertSame(CacheStoreOverride::class, $sprout->overrides()->getOverrideClass('cache'));
+        $this->assertTrue($sprout->overrides()->isOverrideBootable('cache'));
+        $this->assertTrue($sprout->overrides()->hasOverrideBooted('cache'));
+    }
+
+    #[Test, DataProvider('cacheResolvedDataProvider')]
+    public function bootsCorrectly(bool $return): void
+    {
+        $override = new CacheStoreOverride('cache', []);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, function (MockInterface $mock) use ($return) {
+            $mock->makePartial();
+            $mock->shouldReceive('resolved')->withArgs(['cache'])->andReturn($return)->once();
+
+            if ($return) {
+                $mock->shouldReceive('make')
+                     ->with('cache')
+                     ->andReturn($this->mockCacheManager())
+                     ->once();
+            } else {
+                $mock->shouldReceive('afterResolving')
+                     ->withArgs([
+                         'cache',
+                         Mockery::on(static function ($arg) {
+                             return is_callable($arg) && $arg instanceof Closure;
+                         }),
+                     ])
+                     ->once();
+            }
+        });
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        // These are only here because there would be errors if their
+        // corresponding setters were not called
+        $this->assertInstanceOf(Application::class, $override->getApp());
+        $this->assertInstanceOf(Sprout::class, $override->getSprout());
+    }
+
+    #[Test]
+    public function errorsIfOverriddenCacheStoreAlsoUsesBud(): void
+    {
+        $override = new CacheStoreOverride('cache', []);
+
+        $tenant  = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+        $app->make('config')->set('cache.stores.bud-cache', [
+            'driver' => 'bud',
+        ]);
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, static function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'cache',
+                              'bud-cache',
+                          )->andReturn([
+                             'driver' => 'bud',
+                         ]);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        /** @var \Illuminate\Cache\CacheManager $manager */
+        $manager = $app->make('cache');
+
+        $this->expectException(CyclicOverrideException::class);
+        $this->expectExceptionMessage('Attempt to create cyclic bud cache store [bud-cache] detected');
+
+        $manager->store('bud-cache');
+    }
+
+    #[Test]
+    public function keepsTrackOfResolvedBudDrivers(): void
+    {
+        $override = new CacheStoreOverride('mailer', []);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+        $app->make('config')->set('cache.stores.bud-cache', [
+            'driver' => 'bud',
+        ]);
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'cache',
+                              'bud-cache',
+                          )->andReturn([
+                             'driver'    => 'array',
+                             'serialize' => false,
+                         ]);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        /** @var \Illuminate\Cache\CacheManager $manager */
+        $manager = $app->make('cache');
+
+        $manager->store('bud-cache');
+
+        $this->assertContains('bud-cache', $override->getOverrides());
+    }
+
+    #[Test]
+    public function cleansUpResolvedDrivers(): void
+    {
+        $override = new CacheStoreOverride('mailer', []);
+
+        $this->app->forgetInstance('cache');
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+        $app->make('config')->set('cache.stores.bud-cache', [
+            'driver' => 'bud',
+        ]);
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'cache',
+                              'bud-cache',
+                          )->andReturn([
+                             'driver'    => 'array',
+                             'serialize' => false,
+                         ]);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        $this->assertEmpty($override->getOverrides());
+
+        /** @var \Illuminate\Mail\MailManager $manager */
+        $manager = $app->make('cache');
+
+        $manager->store('bud-cache');
+
+        $this->assertNotEmpty($override->getOverrides());
+        $this->assertContains('bud-cache', $override->getOverrides());
+
+        $override->cleanup($tenancy, $tenant);
+
+        $this->assertEmpty($override->getOverrides());
+    }
+
+    #[Test]
+    public function cleansUpNothingWithoutResolvedDrivers(): void
+    {
+        $override = new CacheStoreOverride('mailer', []);
+
+        $this->app->forgetInstance('cache');
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+        $app->make('config')->set('cache.stores.bud-cache', [
+            'driver' => 'bud',
+        ]);
+
+        $sprout  = new Sprout($app, new SettingsRepository());
+        $tenant  = Mockery::mock(Tenant::class, TenantHasResources::class);
+        $tenancy = Mockery::mock(Tenancy::class);
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        $this->assertEmpty($override->getOverrides());
+
+        $app->make('cache');
+
+        $this->assertEmpty($override->getOverrides());
+
+        $override->cleanup($tenancy, $tenant);
+
+        $this->assertEmpty($override->getOverrides());
+    }
+
+    public static function cacheResolvedDataProvider(): array
+    {
+        return [
+            'cache resolved'     => [true],
+            'cache not resolved' => [false],
+        ];
+    }
+}

--- a/tests/Unit/Overrides/Database/BudDatabaseConnectionCreatorTest.php
+++ b/tests/Unit/Overrides/Database/BudDatabaseConnectionCreatorTest.php
@@ -81,8 +81,6 @@ class BudDatabaseConnectionCreatorTest extends UnitTestCase
             } else {
                 $tenant = Mockery::mock(Tenant::class);
             }
-
-
         } else {
             $tenant = null;
         }

--- a/tests/Unit/Overrides/DatabaseConnectionOverrideTest.php
+++ b/tests/Unit/Overrides/DatabaseConnectionOverrideTest.php
@@ -541,8 +541,10 @@ class BroadcastOverrideTest extends UnitTestCase
     public static function broadcastResolvedDataProvider(): array
     {
         return [
-            'broadcast resolved'     => [true],
-            'broadcast not resolved' => [false],
+            'cache resolved no manager override'     => [true],
+            'cache not resolved no manager override' => [false],
+            'cache resolved manager override'        => [true],
+            'cache not resolved  manager override'   => [false],
         ];
     }
 }

--- a/tests/Unit/Overrides/DatabaseConnectionOverrideTest.php
+++ b/tests/Unit/Overrides/DatabaseConnectionOverrideTest.php
@@ -7,19 +7,18 @@ use Closure;
 use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
-use LogicException;
+use Illuminate\Database\DatabaseManager;
 use Mockery;
 use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use RuntimeException;
 use Sprout\Bud\Bud;
 use Sprout\Bud\Contracts\ConfigStore;
 use Sprout\Bud\Exceptions\CyclicOverrideException;
 use Sprout\Bud\Managers\ConfigStoreManager;
-use Sprout\Bud\Overrides\Broadcast\BudBroadcastManager;
 use Sprout\Bud\Overrides\BroadcastConnectionOverride;
 use Sprout\Bud\Overrides\BroadcastManagerOverride;
+use Sprout\Bud\Overrides\DatabaseConnectionOverride;
 use Sprout\Bud\Tests\Unit\UnitTestCase;
 use Sprout\Contracts\BootableServiceOverride;
 use Sprout\Contracts\Tenancy;
@@ -30,7 +29,7 @@ use Sprout\Sprout;
 use Sprout\Support\SettingsRepository;
 use function Sprout\sprout;
 
-class BroadcastOverrideTest extends UnitTestCase
+class DatabaseConnectionOverrideTest extends UnitTestCase
 {
     protected function defineEnvironment($app): void
     {
@@ -39,9 +38,9 @@ class BroadcastOverrideTest extends UnitTestCase
         });
     }
 
-    private function mockBudBroadcastManager(bool $extends = true, ?Closure $callback = null): BudBroadcastManager&MockInterface
+    private function mockDatabaseManager(bool $extends = true, ?Closure $callback = null): DatabaseManager&MockInterface
     {
-        return Mockery::mock(BudBroadcastManager::class, static function (MockInterface $mock) use ($extends, $callback) {
+        return Mockery::mock(DatabaseManager::class, static function (MockInterface $mock) use ($extends, $callback) {
             if ($extends) {
                 $mock->shouldReceive('extend')
                      ->with('bud', Mockery::on(static function ($arg) {
@@ -59,8 +58,7 @@ class BroadcastOverrideTest extends UnitTestCase
     #[Test]
     public function isBuiltCorrectly(): void
     {
-        $this->assertTrue(is_subclass_of(BroadcastManagerOverride::class, BootableServiceOverride::class));
-        $this->assertTrue(is_subclass_of(BroadcastConnectionOverride::class, BootableServiceOverride::class));
+        $this->assertTrue(is_subclass_of(DatabaseConnectionOverride::class, BootableServiceOverride::class));
     }
 
     #[Test]
@@ -69,63 +67,44 @@ class BroadcastOverrideTest extends UnitTestCase
         $sprout = sprout();
 
         config()->set('sprout.overrides', [
-            'broadcast' => [
-                'driver'    => StackedOverride::class,
-                'overrides' => [
-                    BroadcastManagerOverride::class,
-                    BroadcastConnectionOverride::class,
-                ],
+            'database' => [
+                'driver' => DatabaseConnectionOverride::class,
             ],
         ]);
 
-        $this->assertFalse($sprout->overrides()->hasOverride('broadcast'));
+        $this->assertFalse($sprout->overrides()->hasOverride('database'));
 
         $sprout->overrides()->registerOverrides();
 
-        $this->assertTrue($sprout->overrides()->hasOverride('broadcast'));
-        $this->assertSame(StackedOverride::class, $sprout->overrides()->getOverrideClass('broadcast'));
-        $this->assertTrue($sprout->overrides()->isOverrideBootable('broadcast'));
-        $this->assertTrue($sprout->overrides()->hasOverrideBooted('broadcast'));
+        $this->assertTrue($sprout->overrides()->hasOverride('database'));
+        $this->assertSame(DatabaseConnectionOverride::class, $sprout->overrides()->getOverrideClass('database'));
+        $this->assertTrue($sprout->overrides()->isOverrideBootable('database'));
+        $this->assertTrue($sprout->overrides()->hasOverrideBooted('database'));
     }
 
-    #[Test, DataProvider('broadcastResolvedDataProvider')]
+    #[Test, DataProvider('managerResolvedDataProvider')]
     public function bootsCorrectly(bool $return): void
     {
-        $override = new StackedOverride('broadcast', [
-            'overrides' => [
-                BroadcastManagerOverride::class,
-                BroadcastConnectionOverride::class,
-            ],
-        ]);
+        $override = new DatabaseConnectionOverride('database', []);
 
         /** @var \Illuminate\Foundation\Application&MockInterface $app */
         $app = Mockery::mock($this->app, function (MockInterface $mock) use ($return) {
             $mock->makePartial();
 
-            if ($return) {
-                $mock->shouldReceive('forgetInstance')->with(BroadcastManager::class)->once();
-            }
-
-            $mock->shouldReceive('singleton')
-                 ->with(BroadcastManager::class, Mockery::on(static function ($arg) {
-                     return is_callable($arg) && $arg instanceof Closure;
-                 }))
-                 ->once();
-
             $mock->shouldReceive('resolved')
-                 ->withArgs([BroadcastManager::class])
+                 ->withArgs(['db'])
                  ->andReturn($return)
-                 ->times(2);
+                 ->once();
 
             if ($return) {
                 $mock->shouldReceive('make')
-                     ->with(BroadcastManager::class)
-                     ->andReturn($this->mockBudBroadcastManager())
-                     ->times(2);
+                     ->with('db')
+                     ->andReturn($this->mockDatabaseManager())
+                     ->once();
             } else {
                 $mock->shouldReceive('afterResolving')
                      ->withArgs([
-                         BroadcastManager::class,
+                         'db',
                          Mockery::on(static function ($arg) {
                              return is_callable($arg) && $arg instanceof Closure;
                          }),
@@ -147,104 +126,9 @@ class BroadcastOverrideTest extends UnitTestCase
     }
 
     #[Test]
-    public function errorsWithoutManager(): void
-    {
-        $override = new StackedOverride('broadcast', [
-            'overrides' => [
-                BroadcastConnectionOverride::class,
-            ],
-        ]);
-
-        /** @var \Illuminate\Foundation\Application&MockInterface $app */
-        $app = Mockery::mock($this->app, function (MockInterface $mock) {
-            $mock->makePartial();
-        });
-
-        // We have to bind the mock so that the extension can be registered.
-        $app->singleton(BroadcastManager::class, fn () => Mockery::mock(BroadcastManager::class));
-
-        $sprout = new Sprout($app, new SettingsRepository());
-
-        $override->setApp($app)->setSprout($sprout);
-
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Cannot override broadcast connections without the Bud broadcast manager override');
-
-        // This is important, otherwise it doesn't behave nicely with the
-        // afterResolving method.
-        $app->make(BroadcastManager::class);
-
-        $override->boot($app, $sprout);
-    }
-
-    #[Test]
-    public function errorsWithNoTenantSpecificConfig(): void
-    {
-        $override = new StackedOverride('broadcast', [
-            'overrides' => [
-                BroadcastManagerOverride::class,
-                BroadcastConnectionOverride::class,
-            ],
-        ]);
-
-        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
-            $mock->shouldReceive('getTenantIdentifier')->andReturn('my-tenant')->once();
-        });
-
-        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
-            $mock->shouldReceive('check')->andReturnTrue()->once();
-            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
-            $mock->shouldReceive('getName')->andReturn('my-tenancy')->once();
-        });
-
-        /** @var \Illuminate\Foundation\Application&MockInterface $app */
-        $app = Mockery::mock($this->app, static function (MockInterface $mock) use ($tenancy, $tenant) {
-            $mock->makePartial();
-        });
-
-        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
-
-        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
-            $mock->shouldReceive('get')
-                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
-                     $mock->shouldReceive('get')
-                          ->with(
-                              $tenancy,
-                              $tenant,
-                              'broadcast',
-                              'bud-connection',
-                          )->andReturn(null);
-                 }));
-        })));
-
-        $sprout = new Sprout($app, new SettingsRepository());
-
-        $sprout->setCurrentTenancy($tenancy);
-
-        $override->setApp($app)->setSprout($sprout);
-
-        $override->boot($app, $sprout);
-
-        /** @var \Sprout\Bud\Overrides\Broadcast\BudBroadcastManager $manager */
-        $manager = $app->make(BroadcastManager::class);
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to find configuration for [broadcast.bud-connection] for tenant [my-tenant] on tenancy [my-tenancy]');
-
-        $manager->connectUsing('bud-connection', [
-            'driver' => 'bud',
-        ]);
-    }
-
-    #[Test]
     public function errorsIfOverriddenConnectionAlsoUsesBud(): void
     {
-        $override = new StackedOverride('broadcast', [
-            'overrides' => [
-                BroadcastManagerOverride::class,
-                BroadcastConnectionOverride::class,
-            ],
-        ]);
+        $override = new DatabaseConnectionOverride('database', []);
 
         $tenant  = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
         });
@@ -259,18 +143,23 @@ class BroadcastOverrideTest extends UnitTestCase
         });
 
         $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+        $app->make('config')->set('database.connections.bud-connection', [
+            'driver'   => 'bud',
+            'database' => 'bud-database',
+        ]);
 
         $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
             $mock->shouldReceive('get')
-                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                 ->andReturn(Mockery::mock(ConfigStore::class, static function (MockInterface $mock) use ($tenancy, $tenant) {
                      $mock->shouldReceive('get')
                           ->with(
                               $tenancy,
                               $tenant,
-                              'broadcast',
+                              'database',
                               'bud-connection',
                           )->andReturn([
-                             'driver' => 'bud',
+                             'driver'   => 'bud',
+                             'database' => 'bud-database',
                          ]);
                  }));
         })));
@@ -283,26 +172,19 @@ class BroadcastOverrideTest extends UnitTestCase
 
         $override->boot($app, $sprout);
 
-        /** @var \Sprout\Bud\Overrides\Broadcast\BudBroadcastManager $manager */
-        $manager = $app->make(BroadcastManager::class);
+        /** @var DatabaseManager $manager */
+        $manager = $app->make('db');
 
         $this->expectException(CyclicOverrideException::class);
-        $this->expectExceptionMessage('Attempt to create cyclic bud broadcast connection [bud-connection] detected');
+        $this->expectExceptionMessage('Attempt to create cyclic bud database connection [bud-connection] detected');
 
-        $manager->connectUsing('bud-connection', [
-            'driver' => 'bud',
-        ]);
+        $manager->connection('bud-connection');
     }
 
     #[Test]
     public function keepsTrackOfResolvedBudDrivers(): void
     {
-        $override = new StackedOverride('broadcast', [
-            'overrides' => [
-                BroadcastManagerOverride::class,
-                BroadcastConnectionOverride::class,
-            ],
-        ]);
+        $override = new DatabaseConnectionOverride('database', []);
 
         $tenant  = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
         });
@@ -317,6 +199,10 @@ class BroadcastOverrideTest extends UnitTestCase
         });
 
         $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+        $app->make('config')->set('database.connections.bud-connection', [
+            'driver'   => 'bud',
+            'database' => 'bud-database',
+        ]);
 
         $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
             $mock->shouldReceive('get')
@@ -325,10 +211,10 @@ class BroadcastOverrideTest extends UnitTestCase
                           ->with(
                               $tenancy,
                               $tenant,
-                              'broadcast',
+                              'database',
                               'bud-connection',
                           )->andReturn([
-                             'driver' => 'null',
+                             'driver' => 'mysql',
                          ]);
                  }));
         })));
@@ -341,26 +227,19 @@ class BroadcastOverrideTest extends UnitTestCase
 
         $override->boot($app, $sprout);
 
-        /** @var \Sprout\Bud\Overrides\Broadcast\BudBroadcastManager $manager */
-        $manager = $app->make(BroadcastManager::class);
+        /** @var \Illuminate\Database\DatabaseManager $manager */
+        $manager = $app->make('db');
 
-        $manager->connectUsing('bud-connection', [
-            'driver' => 'bud',
-        ]);
+        $manager->connection('bud-connection');
 
-        $this->assertNotEmpty($override->getOverrides()[BroadcastConnectionOverride::class]->getOverrides());
-        $this->assertContains('bud-connection', $override->getOverrides()[BroadcastConnectionOverride::class]->getOverrides());
+        $this->assertNotEmpty($override->getOverrides());
+        $this->assertContains('bud-connection', $override->getOverrides());
     }
 
     #[Test]
     public function cleansUpResolvedDrivers(): void
     {
-        $override = new StackedOverride('filesystem', [
-            'overrides' => [
-                BroadcastManagerOverride::class,
-                BroadcastConnectionOverride::class,
-            ],
-        ]);
+        $override = new DatabaseConnectionOverride('database', []);
 
         $this->app->forgetInstance(BroadcastManager::class);
 
@@ -370,77 +249,9 @@ class BroadcastOverrideTest extends UnitTestCase
         });
 
         $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
-
-        $sprout = new Sprout($app, new SettingsRepository());
-
-        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
-        });
-
-        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
-            $mock->shouldReceive('check')->andReturnTrue()->once();
-            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
-        });
-
-        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
-            $mock->shouldReceive('get')
-                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
-                     $mock->shouldReceive('get')
-                          ->with(
-                              $tenancy,
-                              $tenant,
-                              'broadcast',
-                              'bud-connection',
-                          )->andReturn([
-                             'driver' => 'null',
-                         ]);
-                 }));
-        })));
-
-        $sprout->setCurrentTenancy($tenancy);
-
-        $override->setApp($app)->setSprout($sprout);
-
-        $override->boot($app, $sprout);
-
-        $broadcastOverride = $override->getOverride(BroadcastConnectionOverride::class);
-
-        $this->assertEmpty($broadcastOverride->getOverrides());
-
-        $manager = $app->make(BroadcastManager::class);
-
-        $manager->connectUsing('bud-connection', [
-            'driver' => 'bud',
-        ]);
-
-        $this->assertNotEmpty($broadcastOverride->getOverrides());
-        $this->assertContains('bud-connection', $broadcastOverride->getOverrides());
-
-        $override->cleanup($tenancy, $tenant);
-
-        $this->assertEmpty($broadcastOverride->getOverrides());
-    }
-
-    #[Test]
-    public function cleansUpResolvedDriversFromPreconfiguredConnections(): void
-    {
-        $override = new StackedOverride('filesystem', [
-            'overrides' => [
-                BroadcastManagerOverride::class,
-                BroadcastConnectionOverride::class,
-            ],
-        ]);
-
-        $this->app->forgetInstance(BroadcastManager::class);
-
-        /** @var \Illuminate\Foundation\Application&MockInterface $app */
-        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
-            $mock->makePartial();
-        });
-
-        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
-
-        $app->make('config')->set('broadcasting.connections.bud-connection', [
-            'driver' => 'bud',
+        $app->make('config')->set('database.connections.bud-connection', [
+            'driver'   => 'bud',
+            'database' => 'bud-database',
         ]);
 
         $sprout = new Sprout($app, new SettingsRepository());
@@ -460,10 +271,10 @@ class BroadcastOverrideTest extends UnitTestCase
                           ->with(
                               $tenancy,
                               $tenant,
-                              'broadcast',
+                              'database',
                               'bud-connection',
                           )->andReturn([
-                             'driver' => 'null',
+                             'driver' => 'mysql',
                          ]);
                  }));
         })));
@@ -474,31 +285,24 @@ class BroadcastOverrideTest extends UnitTestCase
 
         $override->boot($app, $sprout);
 
-        $broadcastOverride = $override->getOverride(BroadcastConnectionOverride::class);
+        $this->assertEmpty($override->getOverrides());
 
-        $this->assertEmpty($broadcastOverride->getOverrides());
-
-        $manager = $app->make(BroadcastManager::class);
+        $manager = $app->make('db');
 
         $manager->connection('bud-connection');
 
-        $this->assertNotEmpty($broadcastOverride->getOverrides());
-        $this->assertContains('bud-connection', $broadcastOverride->getOverrides());
+        $this->assertNotEmpty($override->getOverrides());
+        $this->assertContains('bud-connection', $override->getOverrides());
 
         $override->cleanup($tenancy, $tenant);
 
-        $this->assertEmpty($broadcastOverride->getOverrides());
+        $this->assertEmpty($override->getOverrides());
     }
 
     #[Test]
     public function cleansUpNothingWithoutResolvedDrivers(): void
     {
-        $override = new StackedOverride('filesystem', [
-            'overrides' => [
-                BroadcastManagerOverride::class,
-                BroadcastConnectionOverride::class,
-            ],
-        ]);
+        $override = new DatabaseConnectionOverride('database', []);
 
         $this->app->forgetInstance(BroadcastManager::class);
 
@@ -508,9 +312,9 @@ class BroadcastOverrideTest extends UnitTestCase
         });
 
         $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
-
-        $app->make('config')->set('broadcasting.connections.bud-connection', [
-            'driver' => 'bud',
+        $app->make('config')->set('database.connections.bud-connection', [
+            'driver'   => 'bud',
+            'database' => 'bud-database',
         ]);
 
         $sprout = new Sprout($app, new SettingsRepository());
@@ -527,24 +331,20 @@ class BroadcastOverrideTest extends UnitTestCase
 
         $override->boot($app, $sprout);
 
-        $broadcastOverride = $override->getOverride(BroadcastConnectionOverride::class);
+        $this->assertEmpty($override->getOverrides());
 
-        $this->assertEmpty($broadcastOverride->getOverrides());
-
-        $this->assertEmpty($broadcastOverride->getOverrides());
+        $this->assertEmpty($override->getOverrides());
 
         $override->cleanup($tenancy, $tenant);
 
-        $this->assertEmpty($broadcastOverride->getOverrides());
+        $this->assertEmpty($override->getOverrides());
     }
 
-    public static function broadcastResolvedDataProvider(): array
+    public static function managerResolvedDataProvider(): array
     {
         return [
-            'cache resolved no manager override'     => [true],
-            'cache not resolved no manager override' => [false],
-            'cache resolved manager override'        => [true],
-            'cache not resolved  manager override'   => [false],
+            'database manager resolved'     => [true],
+            'database manager not resolved' => [false],
         ];
     }
 }

--- a/tests/Unit/Overrides/DatabaseConnectionOverrideTest.php
+++ b/tests/Unit/Overrides/DatabaseConnectionOverrideTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Sprout\Bud\Tests\Unit\Overrides;
 
 use Closure;
-use Illuminate\Broadcasting\BroadcastManager;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\DatabaseManager;
@@ -16,15 +15,12 @@ use Sprout\Bud\Bud;
 use Sprout\Bud\Contracts\ConfigStore;
 use Sprout\Bud\Exceptions\CyclicOverrideException;
 use Sprout\Bud\Managers\ConfigStoreManager;
-use Sprout\Bud\Overrides\BroadcastConnectionOverride;
-use Sprout\Bud\Overrides\BroadcastManagerOverride;
 use Sprout\Bud\Overrides\DatabaseConnectionOverride;
 use Sprout\Bud\Tests\Unit\UnitTestCase;
 use Sprout\Contracts\BootableServiceOverride;
 use Sprout\Contracts\Tenancy;
 use Sprout\Contracts\Tenant;
 use Sprout\Contracts\TenantHasResources;
-use Sprout\Overrides\StackedOverride;
 use Sprout\Sprout;
 use Sprout\Support\SettingsRepository;
 use function Sprout\sprout;
@@ -241,7 +237,7 @@ class DatabaseConnectionOverrideTest extends UnitTestCase
     {
         $override = new DatabaseConnectionOverride('database', []);
 
-        $this->app->forgetInstance(BroadcastManager::class);
+        $this->app->forgetInstance('db');
 
         /** @var \Illuminate\Foundation\Application&MockInterface $app */
         $app = Mockery::mock($this->app, static function (MockInterface $mock) {
@@ -304,7 +300,7 @@ class DatabaseConnectionOverrideTest extends UnitTestCase
     {
         $override = new DatabaseConnectionOverride('database', []);
 
-        $this->app->forgetInstance(BroadcastManager::class);
+        $this->app->forgetInstance('db');
 
         /** @var \Illuminate\Foundation\Application&MockInterface $app */
         $app = Mockery::mock($this->app, static function (MockInterface $mock) {

--- a/tests/Unit/Overrides/DatabaseConnectionOverrideTest.php
+++ b/tests/Unit/Overrides/DatabaseConnectionOverrideTest.php
@@ -329,8 +329,6 @@ class DatabaseConnectionOverrideTest extends UnitTestCase
 
         $this->assertEmpty($override->getOverrides());
 
-        $this->assertEmpty($override->getOverrides());
-
         $override->cleanup($tenancy, $tenant);
 
         $this->assertEmpty($override->getOverrides());

--- a/tests/Unit/Overrides/Filesystem/BudFilesystemDiskCreatorTest.php
+++ b/tests/Unit/Overrides/Filesystem/BudFilesystemDiskCreatorTest.php
@@ -81,8 +81,6 @@ class BudFilesystemDiskCreatorTest extends UnitTestCase
             } else {
                 $tenant = Mockery::mock(Tenant::class);
             }
-
-
         } else {
             $tenant = null;
         }

--- a/tests/Unit/Overrides/Filesystem/BudFilesystemDiskCreatorTest.php
+++ b/tests/Unit/Overrides/Filesystem/BudFilesystemDiskCreatorTest.php
@@ -5,11 +5,13 @@ namespace Sprout\Bud\Tests\Unit\Overrides\Filesystem;
 
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
+use InvalidArgumentException;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Sprout\Bud\Bud;
 use Sprout\Bud\Contracts\ConfigStore;
 use Sprout\Bud\Managers\ConfigStoreManager;
+use Sprout\Bud\Overrides\Broadcast\BudBroadcastConnectionCreator;
 use Sprout\Bud\Overrides\Filesystem\BudFilesystemDiskCreator;
 use Sprout\Bud\Tests\Unit\UnitTestCase;
 use Sprout\Contracts\Tenancy;
@@ -123,6 +125,32 @@ class BudFilesystemDiskCreatorTest extends UnitTestCase
             $sprout,
             $config,
         );
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenConfigIsMissingName(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [];
+        $sprout  = $this->getSprout($app, false, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $sprout->markAsOutsideContext();
+
+        $this->assertFalse($sprout->withinContext());
+
+        $creator = new BudFilesystemDiskCreator(
+            $manager,
+            $bud,
+            $sprout,
+            $config,
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Filesystem disk name must be provided');
 
         $creator();
     }

--- a/tests/Unit/Overrides/FilesystemDiskOverrideTest.php
+++ b/tests/Unit/Overrides/FilesystemDiskOverrideTest.php
@@ -1,0 +1,469 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Tests\Unit\Overrides;
+
+use Closure;
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Filesystem\FilesystemManager;
+use LogicException;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Contracts\ConfigStore;
+use Sprout\Bud\Exceptions\CyclicOverrideException;
+use Sprout\Bud\Managers\ConfigStoreManager;
+use Sprout\Bud\Overrides\FilesystemDiskOverride;
+use Sprout\Bud\Tests\Unit\UnitTestCase;
+use Sprout\Contracts\BootableServiceOverride;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Contracts\TenantHasResources;
+use Sprout\Overrides\Filesystem\SproutFilesystemManager;
+use Sprout\Overrides\FilesystemManagerOverride;
+use Sprout\Overrides\StackedOverride;
+use Sprout\Sprout;
+use Sprout\Support\SettingsRepository;
+use function Sprout\sprout;
+
+class FilesystemDiskOverrideTest extends UnitTestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], static function (Repository $config) {
+            $config->set('sprout.overrides', []);
+        });
+    }
+
+    private function mockFilesystemManager(): FilesystemManager&MockInterface
+    {
+        return Mockery::mock(SproutFilesystemManager::class, static function (MockInterface $mock) {
+            $mock->shouldReceive('extend')
+                 ->with('bud', Mockery::on(static function ($arg) {
+                     return is_callable($arg) && $arg instanceof Closure;
+                 }))
+                 ->once();
+        });
+    }
+
+    #[Test]
+    public function isBuiltCorrectly(): void
+    {
+        $this->assertTrue(is_subclass_of(FilesystemDiskOverride::class, BootableServiceOverride::class));
+    }
+
+    #[Test]
+    public function isRegisteredWithSproutCorrectly(): void
+    {
+        $sprout = sprout();
+
+        config()->set('sprout.overrides', [
+            'filesystem' => [
+                'driver'    => StackedOverride::class,
+                'overrides' => [
+                    FilesystemManagerOverride::class,
+                    FilesystemDiskOverride::class,
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($sprout->overrides()->hasOverride('filesystem'));
+
+        $sprout->overrides()->registerOverrides();
+
+        $this->assertTrue($sprout->overrides()->hasOverride('filesystem'));
+        $this->assertSame(StackedOverride::class, $sprout->overrides()->getOverrideClass('filesystem'));
+        $this->assertTrue($sprout->overrides()->isOverrideBootable('filesystem'));
+        $this->assertTrue($sprout->overrides()->hasOverrideBooted('filesystem'));
+    }
+
+    #[Test, DataProvider('filesystemResolvedDataProvider')]
+    public function bootsCorrectly(bool $return): void
+    {
+        $overrides = [
+            FilesystemManagerOverride::class,
+            FilesystemDiskOverride::class,
+        ];
+
+        $override = new StackedOverride('filesystem', compact('overrides'));
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, function (MockInterface $mock) use ($return) {
+            $mock->makePartial();
+
+            if ($return) {
+                $mock->shouldReceive('forgetInstance')->with('filesystem')->once();
+            }
+
+            $mock->shouldReceive('singleton')
+                 ->with('filesystem', Mockery::on(static function ($arg) {
+                     return is_callable($arg) && $arg instanceof Closure;
+                 }))
+                 ->once();
+
+            $mock->shouldReceive('resolved')->withArgs(['filesystem'])->andReturn($return)->times(2);
+
+            if ($return) {
+                $mock->shouldReceive('make')
+                     ->with('filesystem')
+                     ->andReturn($this->mockFilesystemManager())
+                     ->times(2);
+            } else {
+                $mock->shouldReceive('afterResolving')
+                     ->withArgs([
+                         'filesystem',
+                         Mockery::on(static function ($arg) {
+                             return is_callable($arg) && $arg instanceof Closure;
+                         }),
+                     ])
+                     ->once();
+            }
+        });
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        // These are only here because there would be errors if their
+        // corresponding setters were not called
+        $this->assertInstanceOf(Application::class, $override->getApp());
+        $this->assertInstanceOf(Sprout::class, $override->getSprout());
+    }
+
+    #[Test]
+    public function errorsWithoutManager(): void
+    {
+        $override = new StackedOverride('filesystem', [
+            'overrides' => [
+                FilesystemDiskOverride::class,
+            ],
+        ]);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        // We have to bind the mock so that the extension can be registered.
+        $app->singleton('filesystem', fn () => Mockery::mock(FilesystemManager::class));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot override filesystem disks without the Sprout filesystem manager override');
+
+        // This is important, otherwise it doesn't behave nicely with the
+        // afterResolving method.
+        $app->make('filesystem');
+
+        $override->boot($app, $sprout);
+    }
+
+    #[Test]
+    public function errorsWithNoTenantSpecificConfig(): void
+    {
+        $override = new StackedOverride('broadcast', [
+            'overrides' => [
+                FilesystemManagerOverride::class,
+                FilesystemDiskOverride::class,
+            ],
+        ]);
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+            $mock->shouldReceive('getTenantIdentifier')->andReturn('my-tenant')->once();
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+            $mock->shouldReceive('getName')->andReturn('my-tenancy')->once();
+        });
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+        $app->make('config')->set('filesystems.disks.bud-disk', [
+            'driver' => 'bud',
+        ]);
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'filesystem',
+                              'bud-disk',
+                          )->andReturn(null);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        /** @var \Sprout\Overrides\Filesystem\SproutFilesystemManager $manager */
+        $manager = $app->make('filesystem');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to find configuration for [filesystem.bud-disk] for tenant [my-tenant] on tenancy [my-tenancy]');
+
+        $manager->disk('bud-disk');
+    }
+
+    #[Test]
+    public function errorsIfOverriddenConnectionAlsoUsesBud(): void
+    {
+        $override = new StackedOverride('broadcast', [
+            'overrides' => [
+                FilesystemManagerOverride::class,
+                FilesystemDiskOverride::class,
+            ],
+        ]);
+
+        $tenant  = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+        $app->make('config')->set('filesystems.disks.bud-disk', [
+            'driver' => 'bud',
+        ]);
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'filesystem',
+                              'bud-disk',
+                          )->andReturn([
+                             'driver' => 'bud',
+                         ]);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        /** @var \Sprout\Overrides\Filesystem\SproutFilesystemManager $manager */
+        $manager = $app->make('filesystem');
+
+        $this->expectException(CyclicOverrideException::class);
+        $this->expectExceptionMessage('Attempt to create cyclic bud filesystem disk [bud-disk] detected');
+
+        $manager->disk('bud-disk');
+    }
+
+    #[Test]
+    public function keepsTrackOfResolvedBudDrivers(): void
+    {
+        $override = new StackedOverride('filesystem', [
+            'overrides' => [
+                FilesystemManagerOverride::class,
+                FilesystemDiskOverride::class,
+            ],
+        ]);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+        $app->make('config')->set('filesystems.disks.bud-disk', [
+            'driver' => 'bud',
+        ]);
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'filesystem',
+                              'bud-disk',
+                          )->andReturn([
+                             'driver' => 'local',
+                             'root'   => storage_path('app'),
+                             'throw'  => false,
+                         ]);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        /** @var \Sprout\Overrides\Filesystem\SproutFilesystemManager $filesystem */
+        $filesystem = $app->make('filesystem');
+
+        $filesystem->disk('bud-disk');
+
+        $this->assertNotEmpty($override->getOverrides()[FilesystemDiskOverride::class]->getOverrides());
+        $this->assertContains('bud-disk', $override->getOverrides()[FilesystemDiskOverride::class]->getOverrides());
+    }
+
+    #[Test]
+    public function cleansUpResolvedDrivers(): void
+    {
+        $override = new StackedOverride('filesystem', [
+            'overrides' => [
+                FilesystemManagerOverride::class,
+                FilesystemDiskOverride::class,
+            ],
+        ]);
+
+        $this->app->forgetInstance('filesystem');
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
+        $app->make('config')->set('filesystems.disks.bud-disk', [
+            'driver' => 'bud',
+        ]);
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'filesystem',
+                              'bud-disk',
+                          )->andReturn([
+                             'driver' => 'local',
+                             'root'   => storage_path('app'),
+                             'throw'  => false,
+                         ]);
+                 }));
+        })));
+
+        $sprout  = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        $filesystemOverride = $override->getOverride(FilesystemDiskOverride::class);
+
+        $this->assertEmpty($filesystemOverride->getOverrides());
+
+        $filesystem = $app->make('filesystem');
+
+        $filesystem->disk('bud-disk');
+
+        $this->assertNotEmpty($filesystemOverride->getOverrides());
+        $this->assertContains('bud-disk', $filesystemOverride->getOverrides());
+
+        $override->cleanup($tenancy, $tenant);
+
+        $this->assertEmpty($filesystemOverride->getOverrides());
+    }
+
+    #[Test]
+    public function cleansUpNothingWithoutResolvedDrivers(): void
+    {
+        $override = new StackedOverride('filesystem', [
+            'overrides' => [
+                FilesystemManagerOverride::class,
+                FilesystemDiskOverride::class,
+            ],
+        ]);
+
+        $this->app->forgetInstance('filesystem');
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $sprout  = new Sprout($app, new SettingsRepository());
+        $tenant  = Mockery::mock(Tenant::class, TenantHasResources::class);
+        $tenancy = Mockery::mock(Tenancy::class);
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        $filesystemOverride = $override->getOverride(FilesystemDiskOverride::class);
+
+        $this->assertEmpty($filesystemOverride->getOverrides());
+
+        $app->make('filesystem');
+
+        $this->assertEmpty($filesystemOverride->getOverrides());
+
+        $override->cleanup($tenancy, $tenant);
+
+        $this->assertEmpty($filesystemOverride->getOverrides());
+    }
+
+    public static function filesystemResolvedDataProvider(): array
+    {
+        return [
+            'filesystem resolved'     => [true],
+            'filesystem not resolved' => [false],
+        ];
+    }
+}

--- a/tests/Unit/Overrides/FilesystemDiskOverrideTest.php
+++ b/tests/Unit/Overrides/FilesystemDiskOverrideTest.php
@@ -170,7 +170,7 @@ class FilesystemDiskOverrideTest extends UnitTestCase
     #[Test]
     public function errorsWithNoTenantSpecificConfig(): void
     {
-        $override = new StackedOverride('broadcast', [
+        $override = new StackedOverride('filesystem', [
             'overrides' => [
                 FilesystemManagerOverride::class,
                 FilesystemDiskOverride::class,
@@ -230,7 +230,7 @@ class FilesystemDiskOverrideTest extends UnitTestCase
     #[Test]
     public function errorsIfOverriddenConnectionAlsoUsesBud(): void
     {
-        $override = new StackedOverride('broadcast', [
+        $override = new StackedOverride('filesystem', [
             'overrides' => [
                 FilesystemManagerOverride::class,
                 FilesystemDiskOverride::class,

--- a/tests/Unit/Overrides/Mailer/BudMailerCreatorTest.php
+++ b/tests/Unit/Overrides/Mailer/BudMailerCreatorTest.php
@@ -1,0 +1,219 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Tests\Unit\Overrides\Mailer;
+
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
+use Illuminate\Mail\MailManager;
+use InvalidArgumentException;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Contracts\ConfigStore;
+use Sprout\Bud\Managers\ConfigStoreManager;
+use Sprout\Bud\Overrides\Filesystem\BudFilesystemDiskCreator;
+use Sprout\Bud\Overrides\Mailer\BudMailerTransportCreator;
+use Sprout\Bud\Tests\Unit\UnitTestCase;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Contracts\TenantHasResources;
+use Sprout\Exceptions\TenancyMissingException;
+use Sprout\Exceptions\TenantMissingException;
+use Sprout\Overrides\Filesystem\SproutFilesystemManager;
+use Sprout\Sprout;
+use Sprout\Support\SettingsRepository;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+class BudMailerCreatorTest extends UnitTestCase
+{
+    private function mockApplication(bool $default = false): Application&Mockery\MockInterface
+    {
+        return Mockery::mock(Application::class, static function (Mockery\MockInterface $mock) use ($default) {
+            $mock->shouldIgnoreMissing();
+        });
+    }
+
+    private function mockManager(bool $driver = true): MailManager&Mockery\MockInterface
+    {
+        return Mockery::mock(MailManager::class, static function (Mockery\MockInterface $mock) use ($driver) {
+            if ($driver) {
+                $mock->shouldReceive('createSymfonyTransport')
+                     ->with(
+                         ['name' => 'fake-mailer', 'driver' => 'fake-mailer', 'transport' => 'null'],
+                     )
+                     ->andReturn(Mockery::mock(TransportInterface::class))
+                     ->once();
+            }
+        });
+    }
+
+    private function mockConfigStoreManager(?Tenancy $tenancy = null, ?Tenant $tenant = null): ConfigStoreManager&Mockery\MockInterface
+    {
+        return Mockery::mock(ConfigStoreManager::class, static function (Mockery\MockInterface $mock) use ($tenancy, $tenant) {
+            if ($tenancy && $tenant) {
+                $mock->shouldReceive('get')
+                     ->with(null)
+                     ->andReturn(Mockery::mock(ConfigStore::class, static function (Mockery\MockInterface $mock) use ($tenancy, $tenant) {
+                         $mock->shouldReceive('get')
+                              ->with(
+                                  $tenancy,
+                                  $tenant,
+                                  'mailer',
+                                  'fake-mailer'
+                              )
+                              ->andReturn([
+                                  'transport' => 'null',
+                              ])
+                              ->once();
+                     }))
+                     ->once();
+            }
+        });
+    }
+
+    private function getSprout(Application $app, bool $withTenancy = true, bool $withTenant = true, bool $withResources = true): Sprout
+    {
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        if ($withTenant) {
+            if ($withResources) {
+                $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (Mockery\MockInterface $mock) {
+                });
+            } else {
+                $tenant = Mockery::mock(Tenant::class);
+            }
+
+
+        } else {
+            $tenant = null;
+        }
+
+        if ($withTenancy) {
+            $sprout->setCurrentTenancy(Mockery::mock(Tenancy::class, static function (Mockery\MockInterface $mock) use ($tenant, $withTenant) {
+                $mock->shouldReceive('check')->andReturn($withTenant)->once();
+
+                if ($withTenant) {
+                    $mock->shouldReceive('tenant')->andReturn($tenant)->twice();
+                } else {
+                    $mock->shouldReceive('getName')->andReturn('my-tenancy')->once();
+                }
+            }));
+        }
+
+        return $sprout;
+    }
+
+    private function getBud(Application $app, ConfigStoreManager $manager): Bud
+    {
+        return new Bud($app, $manager);
+    }
+
+    #[Test]
+    public function canCreateTheDriver(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager();
+        $config  = [
+            'name'   => 'fake-mailer',
+            'driver' => 'fake-mailer',
+        ];
+        $sprout  = $this->getSprout($app);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager($sprout->getCurrentTenancy(), $sprout->getCurrentTenancy()->tenant()));
+
+        $creator = new BudMailerTransportCreator(
+            $manager,
+            $bud,
+            $sprout,
+            'fake-mailer',
+            $config,
+        );
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenOutsideOfContext(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [
+            'name' => 'fake-mailer',
+        ];
+        $sprout  = $this->getSprout($app, false, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $sprout->markAsOutsideContext();
+
+        $this->assertFalse($sprout->withinContext());
+
+        $creator = new BudMailerTransportCreator(
+            $manager,
+            $bud,
+            $sprout,
+            'fake-mailer',
+            $config,
+        );
+
+        $this->expectException(TenancyMissingException::class);
+        $this->expectExceptionMessage('There is no current tenancy');
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenThereIsNoTenancy(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [
+            'name' => 'fake-mailer',
+        ];
+        $sprout  = $this->getSprout($app, false, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $sprout->markAsInContext();
+
+        $this->assertTrue($sprout->withinContext());
+
+        $creator = new BudMailerTransportCreator(
+            $manager,
+            $bud,
+            $sprout,
+            'fake-mailer',
+            $config,
+        );
+
+        $this->expectException(TenancyMissingException::class);
+        $this->expectExceptionMessage('There is no current tenancy');
+
+        $creator();
+    }
+
+    #[Test]
+    public function throwsAnExceptionWhenThereIsNoTenant(): void
+    {
+        $app     = $this->mockApplication();
+        $manager = $this->mockManager(false);
+        $config  = [
+            'name' => 'fake-mailer',
+        ];
+        $sprout  = $this->getSprout($app, true, false);
+        $bud     = $this->getBud($app, $this->mockConfigStoreManager());
+
+        $this->assertTrue($sprout->withinContext());
+
+        $creator = new BudMailerTransportCreator(
+            $manager,
+            $bud,
+            $sprout,
+            'fake-mailer',
+            $config,
+        );
+
+        $this->expectException(TenantMissingException::class);
+        $this->expectExceptionMessage('There is no current tenant for tenancy [my-tenancy]');
+
+        $creator();
+    }
+}

--- a/tests/Unit/Overrides/Mailer/BudMailerCreatorTest.php
+++ b/tests/Unit/Overrides/Mailer/BudMailerCreatorTest.php
@@ -3,16 +3,13 @@ declare(strict_types=1);
 
 namespace Sprout\Bud\Tests\Unit\Overrides\Mailer;
 
-use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
 use Illuminate\Mail\MailManager;
-use InvalidArgumentException;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Sprout\Bud\Bud;
 use Sprout\Bud\Contracts\ConfigStore;
 use Sprout\Bud\Managers\ConfigStoreManager;
-use Sprout\Bud\Overrides\Filesystem\BudFilesystemDiskCreator;
 use Sprout\Bud\Overrides\Mailer\BudMailerTransportCreator;
 use Sprout\Bud\Tests\Unit\UnitTestCase;
 use Sprout\Contracts\Tenancy;
@@ -20,7 +17,6 @@ use Sprout\Contracts\Tenant;
 use Sprout\Contracts\TenantHasResources;
 use Sprout\Exceptions\TenancyMissingException;
 use Sprout\Exceptions\TenantMissingException;
-use Sprout\Overrides\Filesystem\SproutFilesystemManager;
 use Sprout\Sprout;
 use Sprout\Support\SettingsRepository;
 use Symfony\Component\Mailer\Transport\TransportInterface;
@@ -83,8 +79,6 @@ class BudMailerCreatorTest extends UnitTestCase
             } else {
                 $tenant = Mockery::mock(Tenant::class);
             }
-
-
         } else {
             $tenant = null;
         }

--- a/tests/Unit/Overrides/MailerOverrideTest.php
+++ b/tests/Unit/Overrides/MailerOverrideTest.php
@@ -131,7 +131,7 @@ class MailerOverrideTest extends UnitTestCase
             $mock->makePartial();
         });
 
-        $app->make('config')->set('multitenancy.defaults.config', 'mailer');
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
         $app->make('config')->set('mail.mailers.bud-mailer', [
             'transport' => 'bud',
         ]);
@@ -178,7 +178,7 @@ class MailerOverrideTest extends UnitTestCase
             $mock->makePartial();
         });
 
-        $app->make('config')->set('multitenancy.defaults.config', 'mailer');
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
         $app->make('config')->set('mail.mailers.bud-mailer', [
             'transport' => 'bud',
         ]);
@@ -236,7 +236,7 @@ class MailerOverrideTest extends UnitTestCase
             $mock->makePartial();
         });
 
-        $app->make('config')->set('multitenancy.defaults.config', 'mailer');
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
         $app->make('config')->set('mail.mailers.bud-mailer', [
             'transport' => 'bud',
         ]);
@@ -301,7 +301,7 @@ class MailerOverrideTest extends UnitTestCase
             $mock->makePartial();
         });
 
-        $app->make('config')->set('multitenancy.defaults.config', 'mailer');
+        $app->make('config')->set('multitenancy.defaults.config', 'filesystem');
         $app->make('config')->set('mail.mailers.bud-mailer', [
             'transport' => 'bud',
         ]);

--- a/tests/Unit/Overrides/MailerOverrideTest.php
+++ b/tests/Unit/Overrides/MailerOverrideTest.php
@@ -1,0 +1,337 @@
+<?php
+declare(strict_types=1);
+
+namespace Sprout\Bud\Tests\Unit\Overrides;
+
+use Closure;
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Mail\MailManager;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Sprout\Bud\Bud;
+use Sprout\Bud\Contracts\ConfigStore;
+use Sprout\Bud\Exceptions\CyclicOverrideException;
+use Sprout\Bud\Managers\ConfigStoreManager;
+use Sprout\Bud\Overrides\FilesystemDiskOverride;
+use Sprout\Bud\Overrides\MailerOverride;
+use Sprout\Bud\Tests\Unit\UnitTestCase;
+use Sprout\Contracts\BootableServiceOverride;
+use Sprout\Contracts\Tenancy;
+use Sprout\Contracts\Tenant;
+use Sprout\Contracts\TenantHasResources;
+use Sprout\Overrides\FilesystemManagerOverride;
+use Sprout\Overrides\StackedOverride;
+use Sprout\Sprout;
+use Sprout\Support\SettingsRepository;
+use function Sprout\sprout;
+
+class MailerOverrideTest extends UnitTestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], static function (Repository $config) {
+            $config->set('sprout.overrides', []);
+        });
+    }
+
+    private function mockMailManager(): MailManager&MockInterface
+    {
+        return Mockery::mock(MailManager::class, static function (MockInterface $mock) {
+            $mock->shouldReceive('extend')
+                 ->with('bud', Mockery::on(static function ($arg) {
+                     return is_callable($arg) && $arg instanceof Closure;
+                 }))
+                 ->once();
+        });
+    }
+
+    #[Test]
+    public function isBuiltCorrectly(): void
+    {
+        $this->assertTrue(is_subclass_of(MailerOverride::class, BootableServiceOverride::class));
+    }
+
+    #[Test]
+    public function isRegisteredWithSproutCorrectly(): void
+    {
+        $sprout = sprout();
+
+        config()->set('sprout.overrides', [
+            'mailer' => [
+                'driver' => MailerOverride::class,
+            ],
+        ]);
+
+        $this->assertFalse($sprout->overrides()->hasOverride('mailer'));
+
+        $sprout->overrides()->registerOverrides();
+
+        $this->assertTrue($sprout->overrides()->hasOverride('mailer'));
+        $this->assertSame(MailerOverride::class, $sprout->overrides()->getOverrideClass('mailer'));
+        $this->assertTrue($sprout->overrides()->isOverrideBootable('mailer'));
+        $this->assertTrue($sprout->overrides()->hasOverrideBooted('mailer'));
+    }
+
+    #[Test, DataProvider('mailerResolvedDataProvider')]
+    public function bootsCorrectly(bool $return): void
+    {
+        $override = new MailerOverride('mailer', []);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, function (MockInterface $mock) use ($return) {
+            $mock->makePartial();
+            $mock->shouldReceive('resolved')->withArgs(['mail.manager'])->andReturn($return)->once();
+
+            if ($return) {
+                $mock->shouldReceive('make')
+                     ->with('mail.manager')
+                     ->andReturn($this->mockMailManager())
+                     ->once();
+            } else {
+                $mock->shouldReceive('afterResolving')
+                     ->withArgs([
+                         'mail.manager',
+                         Mockery::on(static function ($arg) {
+                             return is_callable($arg) && $arg instanceof Closure;
+                         }),
+                     ])
+                     ->once();
+            }
+        });
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        // These are only here because there would be errors if their
+        // corresponding setters were not called
+        $this->assertInstanceOf(Application::class, $override->getApp());
+        $this->assertInstanceOf(Sprout::class, $override->getSprout());
+    }
+
+    #[Test]
+    public function errorsIfOverriddenMailerAlsoUsesBud(): void
+    {
+        $override = new MailerOverride('mailer', []);
+
+        $tenant  = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'mailer');
+        $app->make('config')->set('mail.mailers.bud-mailer', [
+            'transport' => 'bud',
+        ]);
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'mailer',
+                              'bud-mailer',
+                          )->andReturn([
+                             'transport' => 'bud',
+                         ]);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        /** @var \Illuminate\Mail\MailManager $manager */
+        $manager = $app->make('mail.manager');
+
+        $this->expectException(CyclicOverrideException::class);
+        $this->expectExceptionMessage('Attempt to create cyclic bud mailer [bud-mailer] detected');
+
+        $manager->mailer('bud-mailer');
+    }
+
+    #[Test]
+    public function keepsTrackOfResolvedBudDrivers(): void
+    {
+        $override = new MailerOverride('mailer', []);
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'mailer');
+        $app->make('config')->set('mail.mailers.bud-mailer', [
+            'transport' => 'bud',
+        ]);
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'mailer',
+                              'bud-mailer',
+                          )->andReturn([
+                             'transport' => 'smtp',
+                             'port' => 25,
+                             'host' => 'localhost'
+                         ]);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        /** @var \Illuminate\Mail\MailManager $manager */
+        $manager = $app->make('mail.manager');
+
+        $manager->mailer('bud-mailer');
+
+        $this->assertContains('bud-mailer', $override->getOverrides());
+    }
+
+    #[Test]
+    public function cleansUpResolvedDrivers(): void
+    {
+        $override = new MailerOverride('mailer', []);
+
+        $this->app->forgetInstance('mail.manager');
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'mailer');
+        $app->make('config')->set('mail.mailers.bud-mailer', [
+            'transport' => 'bud',
+        ]);
+
+        $tenant = Mockery::mock(Tenant::class, TenantHasResources::class, static function (MockInterface $mock) {
+        });
+
+        $tenancy = Mockery::mock(Tenancy::class, static function (MockInterface $mock) use ($tenant) {
+            $mock->shouldReceive('check')->andReturnTrue()->once();
+            $mock->shouldReceive('tenant')->andReturn($tenant)->once();
+        });
+
+        $app->singleton(Bud::class, fn () => new Bud($app, Mockery::mock(ConfigStoreManager::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+            $mock->shouldReceive('get')
+                 ->andReturn(Mockery::mock(ConfigStore::class, function (MockInterface $mock) use ($tenancy, $tenant) {
+                     $mock->shouldReceive('get')
+                          ->with(
+                              $tenancy,
+                              $tenant,
+                              'mailer',
+                              'bud-mailer',
+                          )->andReturn([
+                             'transport' => 'smtp',
+                             'port' => 25,
+                             'host' => 'localhost'
+                         ]);
+                 }));
+        })));
+
+        $sprout = new Sprout($app, new SettingsRepository());
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        $this->assertEmpty($override->getOverrides());
+
+        /** @var \Illuminate\Mail\MailManager $manager */
+        $manager = $app->make('mail.manager');
+
+        $manager->mailer('bud-mailer');
+
+        $this->assertNotEmpty($override->getOverrides());
+        $this->assertContains('bud-mailer', $override->getOverrides());
+
+        $override->cleanup($tenancy, $tenant);
+
+        $this->assertEmpty($override->getOverrides());
+    }
+
+    #[Test]
+    public function cleansUpNothingWithoutResolvedDrivers(): void
+    {
+        $override = new MailerOverride('mailer', []);
+
+        $this->app->forgetInstance('mail.manager');
+
+        /** @var \Illuminate\Foundation\Application&MockInterface $app */
+        $app = Mockery::mock($this->app, static function (MockInterface $mock) {
+            $mock->makePartial();
+        });
+
+        $app->make('config')->set('multitenancy.defaults.config', 'mailer');
+        $app->make('config')->set('mail.mailers.bud-mailer', [
+            'transport' => 'bud',
+        ]);
+
+        $sprout  = new Sprout($app, new SettingsRepository());
+        $tenant  = Mockery::mock(Tenant::class, TenantHasResources::class);
+        $tenancy = Mockery::mock(Tenancy::class);
+
+        $sprout->setCurrentTenancy($tenancy);
+
+        $override->setApp($app)->setSprout($sprout);
+
+        $override->boot($app, $sprout);
+
+        $this->assertEmpty($override->getOverrides());
+
+        $app->make('mail.manager');
+
+        $this->assertEmpty($override->getOverrides());
+
+        $override->cleanup($tenancy, $tenant);
+
+        $this->assertEmpty($override->getOverrides());
+    }
+
+    public static function mailerResolvedDataProvider(): array
+    {
+        return [
+            'mailer resolved'     => [true],
+            'mailer not resolved' => [false],
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds overrides for a handful of core services, addressing #5, which includes:

- [x] #6 
- [x] #7 
- [x] #8 
- [x] #9 
- [x] #10 
- [x] #11 
- [x] #12 